### PR TITLE
Wire Daystar Health SPA auth flow to Frappe (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ MIT
 
 ## Changelog
 
+### 2026-04-29 — Phase 1F (Issue #4): Daystar Health SPA — auth flow wired to Frappe
+- Slice 1 of 5 wiring the `/daystar-health` SPA to real Frappe APIs.
+- New `practice_resolver.get_active_practice(user)` deep module — returns the user's active Practice or raises `frappe.PermissionError` for Guest / no-membership users. Reusable across all later Daystar Health endpoints.
+- New page bootstrap `www/daystar_health.py` exposes `csrf_token`, `session_user`, and `has_practice` to the SPA template; new `meridian-api.js` helper centralises CSRF + JSON conventions for every later screen (`call`, `resource`, `login`, `recoverPassword`, `logout`).
+- Replaced mock auth in `meridian-auth.jsx` with real `/api/method/login` and `frappe.core.doctype.user.user.reset_password` calls. New `MNoPracticeScreen` for authenticated users without a Practice Member row, with sign-out wired to `/api/method/logout`.
+- SPA first-render routing reads the bootstrap and chooses login / no-practice / dashboard at mount time — no more login-screen flicker for already-authenticated users.
+- Tests: 3 Python unit tests for `practice_resolver` + 5 Playwright tests covering anonymous, invalid creds, post-login routing, already-logged-in skip, and sign-out.
+- Bug fix: renamed `daystar-health.py` → `daystar_health.py` so Frappe's website controller resolver finds it (resolver maps hyphenated `.html` to underscored `.py`).
+
 ### 2026-04-22 — Phase 6: Doctor Self-Registration (OTP + Yoco)
 - New 3-step `/signup` funnel: details → email OTP → Yoco checkout. Replaces `/register` and `/register/doctor` (deleted).
 - Yoco webhook auto-provisions on `payment.succeeded` (no admin approval). Idempotent re-fires; failures flip the PRR to `Provisioning Failed` with the traceback recorded.

--- a/medic_plus/api/practice_resolver.py
+++ b/medic_plus/api/practice_resolver.py
@@ -1,0 +1,22 @@
+"""Resolve the active Practice for a user.
+
+The Daystar Health SPA and its endpoints require a Practice context for every
+operation. This module is the single source of truth for that resolution, and
+the place to look when adding a new endpoint that needs tenant scoping.
+"""
+
+import frappe
+
+
+def get_active_practice(user: str | None = None) -> str:
+    user = user or frappe.session.user
+    if user == "Guest":
+        raise frappe.PermissionError("Sign in to access Daystar Health.")
+    practice = frappe.db.get_value(
+        "Practice Member", {"user": user}, "practice"
+    )
+    if not practice:
+        raise frappe.PermissionError(
+            "Your account is not linked to a practice."
+        )
+    return practice

--- a/medic_plus/api/test_daystar_health.py
+++ b/medic_plus/api/test_daystar_health.py
@@ -1,0 +1,84 @@
+"""
+Tests for medic_plus.api.daystar_health and supporting modules.
+
+The Daystar Health SPA is served at /daystar-health and depends on:
+- medic_plus.api.practice_resolver — resolves the active Practice for a user,
+  raising PermissionError when no membership exists or the user is Guest.
+- medic_plus.api.daystar_health (forthcoming) — whitelisted endpoints for the SPA.
+
+All external calls (frappe.db, frappe.session) are mocked. No documents are
+created in the database.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+
+def setUpModule():
+    """Bind frappe LocalProxy objects so mock patching works correctly.
+
+    See test_data_access.setUpModule for the rationale: Python 3.14 + LocalProxy
+    needs the ContextVar bound, and frappe.throw() needs cache.hget() and lang.
+    """
+    frappe.local.session = frappe._dict(user="test@example.test")
+    frappe.local.conf = frappe._dict(developer_mode=0)
+    frappe.local.flags = frappe._dict()
+    frappe.local.lang = "en"
+    frappe.local.message_log = []
+    frappe.local.error_log = []
+    frappe.local.debug_log = []
+    frappe.local.response = frappe._dict()
+
+    cache_mock = MagicMock()
+    cache_mock.hget.return_value = {}
+    frappe.cache = cache_mock
+
+    # frappe.db is a LocalProxy backed by a ContextVar. Bind it with a MagicMock
+    # so per-test patch.object(...) calls can introspect it without RuntimeError.
+    frappe.local.db = MagicMock()
+
+
+class TestPracticeResolver(unittest.TestCase):
+    """Behavior tests for practice_resolver.get_active_practice.
+
+    The resolver is the single source of truth for "which Practice does this user
+    belong to" across all Daystar Health endpoints. Every behavior here describes
+    a contract callers rely on; implementation detail (which doctype it queries,
+    which field it reads) is intentionally not asserted.
+    """
+
+    def _import(self):
+        from medic_plus.api import practice_resolver
+        return practice_resolver
+
+    def test_returns_practice_for_member(self):
+        """Given a user with a Practice Member row, the resolver returns the
+        Practice name."""
+        m = self._import()
+        with patch("medic_plus.api.practice_resolver.frappe.db.get_value",
+                   return_value="PRAC-00001") as gv:
+            result = m.get_active_practice(user="doctor@example.test")
+        self.assertEqual(result, "PRAC-00001")
+        gv.assert_called_once()
+
+    def test_raises_for_user_with_no_practice_membership(self):
+        """A user without a Practice Member row cannot reach Daystar Health
+        data. The resolver raises PermissionError so callers can surface the
+        no-practice error card without leaking which Practices exist."""
+        m = self._import()
+        with patch("medic_plus.api.practice_resolver.frappe.db.get_value",
+                   return_value=None):
+            with self.assertRaises(frappe.PermissionError):
+                m.get_active_practice(user="orphan@example.test")
+
+    def test_raises_for_guest(self):
+        """Guest users are anonymous visitors. They never have a Practice
+        Member row, but we reject them before the database query so an
+        anonymous visit cannot exfiltrate practice membership state."""
+        m = self._import()
+        with patch("medic_plus.api.practice_resolver.frappe.db.get_value") as gv:
+            with self.assertRaises(frappe.PermissionError):
+                m.get_active_practice(user="Guest")
+        gv.assert_not_called()

--- a/medic_plus/public/daystar-health/meridian-api.js
+++ b/medic_plus/public/daystar-health/meridian-api.js
@@ -1,0 +1,134 @@
+// Daystar Health SPA API client.
+// Reads bootstrap state injected by daystar-health.py: csrfToken, sessionUser,
+// hasPractice. Wraps fetch with CSRF + JSON conventions used by every screen.
+
+(function () {
+  const bootstrap = window.__DAYSTAR_HEALTH__ || {};
+
+  function showError(message) {
+    if (window.frappe && typeof window.frappe.show_alert === "function") {
+      window.frappe.show_alert({ message, indicator: "red" }, 5);
+    } else {
+      // Fallback for the standalone page where frappe.show_alert isn't loaded.
+      console.error("[meridian-api]", message);
+      alert(message);
+    }
+  }
+
+  async function parseJson(response) {
+    const text = await response.text();
+    if (!text) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  function extractServerMessage(payload, fallback) {
+    if (!payload || typeof payload === "string") return payload || fallback;
+    if (payload.message) return payload.message;
+    if (payload._server_messages) {
+      try {
+        const list = JSON.parse(payload._server_messages);
+        if (list.length) return JSON.parse(list[0]).message || fallback;
+      } catch {}
+    }
+    if (payload.exc_type) return `${payload.exc_type}: ${payload.exception || fallback}`;
+    return fallback;
+  }
+
+  async function call(method, args = {}) {
+    const response = await fetch(`/api/method/${method}`, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Frappe-CSRF-Token": bootstrap.csrfToken || "",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(args),
+    });
+    const payload = await parseJson(response);
+    if (!response.ok) {
+      const msg = extractServerMessage(payload, response.statusText);
+      const err = new Error(msg);
+      err.status = response.status;
+      err.payload = payload;
+      throw err;
+    }
+    return payload && payload.message !== undefined ? payload.message : payload;
+  }
+
+  async function resource(doctype, params = {}) {
+    const search = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) continue;
+      search.append(key, typeof value === "string" ? value : JSON.stringify(value));
+    }
+    const url = `/api/resource/${encodeURIComponent(doctype)}?${search.toString()}`;
+    const response = await fetch(url, {
+      method: "GET",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    });
+    const payload = await parseJson(response);
+    if (!response.ok) {
+      const msg = extractServerMessage(payload, response.statusText);
+      const err = new Error(msg);
+      err.status = response.status;
+      err.payload = payload;
+      throw err;
+    }
+    return payload;
+  }
+
+  async function login(email, pwd) {
+    // Frappe's /api/method/login accepts form-encoded usr/pwd and sets the
+    // session cookie. It returns home_page on success.
+    const body = new URLSearchParams({ usr: email, pwd });
+    const response = await fetch("/api/method/login", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+    const payload = await parseJson(response);
+    if (!response.ok) {
+      const msg = extractServerMessage(payload, "Invalid email or password.");
+      const err = new Error(msg);
+      err.status = response.status;
+      throw err;
+    }
+    return payload;
+  }
+
+  async function recoverPassword(email) {
+    return call("frappe.core.doctype.user.user.reset_password", { user: email });
+  }
+
+  async function logout() {
+    await fetch("/api/method/logout", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "X-Frappe-CSRF-Token": bootstrap.csrfToken || "",
+        Accept: "application/json",
+      },
+    });
+    window.location.href = "/daystar-health";
+  }
+
+  window.meridianApi = {
+    bootstrap,
+    sessionUser: bootstrap.sessionUser || "Guest",
+    hasPractice: !!bootstrap.hasPractice,
+    isAuthenticated: bootstrap.sessionUser && bootstrap.sessionUser !== "Guest",
+    call,
+    resource,
+    login,
+    recoverPassword,
+    logout,
+    showError,
+  };
+})();

--- a/medic_plus/public/daystar-health/meridian-auth.jsx
+++ b/medic_plus/public/daystar-health/meridian-auth.jsx
@@ -1,0 +1,213 @@
+// Meridian auth screens — wired to Frappe via window.meridianApi.
+function MLoginScreen({ go }) {
+  const [email, setEmail] = mUseState('');
+  const [pw, setPw] = mUseState('');
+  const [show, setShow] = mUseState(false);
+  const [loading, setLoading] = mUseState(false);
+  const [error, setError] = mUseState(null);
+  const Logo = window.MIcons.Logo;
+
+  const submit = async (e) => {
+    e.preventDefault();
+    if (!email || !pw) {
+      setError('Enter your email and password.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await window.meridianApi.login(email, pw);
+      // After login, reload so daystar-health.py re-evaluates session and
+      // has_practice. The page entry decides where to route from there.
+      window.location.href = '/daystar-health';
+    } catch (err) {
+      setError(err.message || 'Sign-in failed. Check your credentials and try again.');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-shell">
+      <div className="auth-card fade-in">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 28 }}>
+          <Logo size={28} />
+          <div style={{ lineHeight: 1.1 }}>
+            <div style={{ fontSize: 15, fontWeight: 600 }}>Daystar</div>
+            <div style={{ fontSize: 10.5, color: 'var(--text-dim)', letterSpacing: '0.06em', textTransform: 'uppercase', fontWeight: 500 }}>Health</div>
+          </div>
+        </div>
+        <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 6px', letterSpacing: '-0.02em' }}>Sign in to your practice</h1>
+        <p style={{ fontSize: 13.5, color: 'var(--text-muted)', margin: '0 0 24px' }}>Secure access to your patients, schedule, and records.</p>
+
+        <form onSubmit={submit}>
+          <div className="field">
+            <label className="label">Provider email</label>
+            <div style={{ position: 'relative' }}>
+              <window.MIcons.Mail size={15} style={{ position: 'absolute', left: 12, top: 12, color: 'var(--text-dim)' }} />
+              <input
+                className="input"
+                style={{ paddingLeft: 36 }}
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                type="text"
+                autoComplete="username"
+                required
+                data-testid="login-email"
+              />
+            </div>
+          </div>
+          <div className="field">
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+              <label className="label">Password</label>
+              <button type="button" onClick={() => go('recover')} style={{ background: 'none', border: 'none', color: 'var(--accent-text)', fontSize: 12, fontWeight: 500 }}>Forgot?</button>
+            </div>
+            <div style={{ position: 'relative' }}>
+              <window.MIcons.Lock size={15} style={{ position: 'absolute', left: 12, top: 12, color: 'var(--text-dim)' }} />
+              <input
+                className="input"
+                style={{ paddingLeft: 36, paddingRight: 36 }}
+                value={pw}
+                onChange={e => setPw(e.target.value)}
+                type={show ? 'text' : 'password'}
+                autoComplete="current-password"
+                required
+                data-testid="login-password"
+              />
+              <button type="button" onClick={() => setShow(!show)} style={{ position: 'absolute', right: 8, top: 8, background: 'transparent', border: 'none', color: 'var(--text-dim)', padding: 6 }}>
+                {show ? <window.MIcons.EyeOff size={15} /> : <window.MIcons.Eye size={15} />}
+              </button>
+            </div>
+          </div>
+          {error && (
+            <div
+              role="alert"
+              data-testid="login-error"
+              style={{ padding: '10px 12px', background: 'var(--danger-soft)', border: '1px solid var(--danger)', borderRadius: 8, fontSize: 12.5, color: 'var(--danger)', margin: '4px 0 14px' }}
+            >
+              {error}
+            </div>
+          )}
+          <div style={{ padding: '10px 12px', background: 'var(--bg-subtle)', border: '1px solid var(--border)', borderRadius: 8, fontSize: 11.5, color: 'var(--text-muted)', display: 'flex', gap: 8, alignItems: 'flex-start', margin: '4px 0 18px' }}>
+            <window.MIcons.Lock size={13} style={{ marginTop: 1, flexShrink: 0 }} />
+            <span>Protected health information. Sign-ins are logged for audit. By continuing you agree to the access policy.</span>
+          </div>
+          <button type="submit" className="btn btn-primary btn-lg btn-block" disabled={loading} data-testid="login-submit">
+            {loading ? 'Signing in…' : 'Sign in'} {!loading && <window.MIcons.ArrowRight size={15} />}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function MRecoverScreen({ go }) {
+  const [step, setStep] = mUseState(1);
+  const [email, setEmail] = mUseState('');
+  const [loading, setLoading] = mUseState(false);
+  const [error, setError] = mUseState(null);
+  const Logo = window.MIcons.Logo;
+
+  const submit = async (e) => {
+    e.preventDefault();
+    if (!email) {
+      setError('Enter your email.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await window.meridianApi.recoverPassword(email);
+      setStep(2);
+    } catch (err) {
+      // Frappe returns a localised "User not found" or similar; surface it.
+      setError(err.message || "We couldn't send a reset link. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-shell">
+      <div className="auth-card fade-in">
+        <button onClick={() => go('login')} className="btn btn-ghost btn-sm" style={{ marginLeft: -8, marginBottom: 16 }}>
+          <window.MIcons.ArrowLeft size={14} /> Back to sign in
+        </button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 }}>
+          <Logo size={26} />
+          <div style={{ fontSize: 14, fontWeight: 600 }}>Daystar Health</div>
+        </div>
+        {step === 1 ? (
+          <>
+            <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 6px', letterSpacing: '-0.02em' }}>Reset your password</h1>
+            <p style={{ fontSize: 13.5, color: 'var(--text-muted)', margin: '0 0 24px' }}>Enter your provider email and we'll send a secure recovery link.</p>
+            <form onSubmit={submit}>
+              <div className="field">
+                <label className="label">Provider email</label>
+                <input
+                  className="input"
+                  type="email"
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  required
+                  data-testid="recover-email"
+                />
+              </div>
+              {error && (
+                <div role="alert" data-testid="recover-error" style={{ padding: '10px 12px', background: 'var(--danger-soft)', border: '1px solid var(--danger)', borderRadius: 8, fontSize: 12.5, color: 'var(--danger)', margin: '4px 0 14px' }}>
+                  {error}
+                </div>
+              )}
+              <button type="submit" className="btn btn-primary btn-lg btn-block" disabled={loading} data-testid="recover-submit">
+                {loading ? 'Sending…' : 'Send recovery link'} {!loading && <window.MIcons.ArrowRight size={15} />}
+              </button>
+              <p style={{ fontSize: 11.5, color: 'var(--text-dim)', marginTop: 14, textAlign: 'center' }}>
+                For security, your account locks after repeated failed attempts. Contact your practice admin if you've been locked out.
+              </p>
+            </form>
+          </>
+        ) : (
+          <>
+            <div style={{ width: 56, height: 56, borderRadius: 14, background: 'var(--accent-soft)', display: 'grid', placeItems: 'center', marginBottom: 18 }}>
+              <window.MIcons.Mail size={26} stroke="var(--accent)" />
+            </div>
+            <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 6px', letterSpacing: '-0.02em' }}>Check your inbox</h1>
+            <p style={{ fontSize: 13.5, color: 'var(--text-muted)', margin: '0 0 8px' }}>Recovery link sent to:</p>
+            <p data-testid="recover-success-email" style={{ fontFamily: 'var(--font-mono)', fontSize: 13, padding: '10px 14px', background: 'var(--bg-subtle)', border: '1px solid var(--border)', borderRadius: 8, margin: '0 0 20px' }}>{email}</p>
+            <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: '0 0 20px' }}>Link expires shortly. Didn't get it? Check spam or resend.</p>
+            <button className="btn btn-secondary btn-block" onClick={() => setStep(1)}>Try a different email</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MNoPracticeScreen() {
+  const Logo = window.MIcons.Logo;
+  return (
+    <div className="auth-shell">
+      <div className="auth-card fade-in" data-testid="no-practice-card">
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 24 }}>
+          <Logo size={26} />
+          <div style={{ fontSize: 14, fontWeight: 600 }}>Daystar Health</div>
+        </div>
+        <div style={{ width: 56, height: 56, borderRadius: 14, background: 'var(--warn-soft)', display: 'grid', placeItems: 'center', marginBottom: 18 }}>
+          <window.MIcons.AlertTriangle size={26} stroke="var(--warn)" />
+        </div>
+        <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 6px', letterSpacing: '-0.02em' }}>Practice not linked</h1>
+        <p style={{ fontSize: 13.5, color: 'var(--text-muted)', margin: '0 0 18px' }}>Your account isn't linked to a practice. Contact your administrator to be added as a Practice Member.</p>
+        <button
+          className="btn btn-secondary btn-block"
+          onClick={() => window.meridianApi.logout()}
+          data-testid="no-practice-signout"
+        >
+          Sign out
+        </button>
+      </div>
+    </div>
+  );
+}
+
+window.MLoginScreen = MLoginScreen;
+window.MRecoverScreen = MRecoverScreen;
+window.MNoPracticeScreen = MNoPracticeScreen;

--- a/medic_plus/public/daystar-health/meridian-dashboard.jsx
+++ b/medic_plus/public/daystar-health/meridian-dashboard.jsx
@@ -1,0 +1,175 @@
+// Daystar Health Dashboard ("Today")
+function MDashboardScreen({ go }) {
+  const appts = window.MH_DATA.TODAY_APPTS;
+  const patients = window.MH_DATA.PATIENTS;
+
+  const kpis = [
+    { label: 'Today\'s appointments', value: '12', sub: '3 checked in · 1 in room', trend: [8, 10, 12, 9, 11, 13, 12], color: '#2563eb' },
+    { label: 'Active patients', value: '1,284', sub: '+18 this month', trend: [50, 53, 56, 60, 63, 66, 70], color: '#10b981' },
+    { label: 'Outstanding labs', value: '23', sub: '4 critical results', trend: [18, 20, 19, 22, 21, 24, 23], color: '#f59e0b' },
+    { label: 'Pending refills', value: '38', sub: '12 awaiting review', trend: [30, 32, 36, 34, 40, 38, 38], color: '#8b5cf6' },
+  ];
+
+  const week = [
+    { d: 'Mon', visits: 18 }, { d: 'Tue', visits: 22 }, { d: 'Wed', visits: 19 },
+    { d: 'Thu', visits: 24 }, { d: 'Fri', visits: 21 }, { d: 'Sat', visits: 8 }, { d: 'Sun', visits: 0 },
+  ];
+
+  return (
+    <div className="page fade-in">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 24, gap: 16, flexWrap: 'wrap' }}>
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 4px', letterSpacing: '-0.02em' }}>
+            Good morning, Dr. Patel
+          </h1>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>Wednesday, April 29 · {appts.length} patients on your schedule today.</p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn btn-secondary btn-sm"><window.MIcons.Calendar size={14} /> View full schedule</button>
+          <button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> New appointment</button>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
+        {kpis.map((k, i) => (
+          <div key={i} className="kpi-tile">
+            <div className="kpi-label">{k.label}</div>
+            <div className="kpi-value">{k.value}</div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+              <span style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{k.sub}</span>
+              <div style={{ width: 70 }}><window.Sparkline data={k.trend} color={k.color} height={26} /></div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.6fr 1fr', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
+        {/* Today's schedule */}
+        <div className="card">
+          <div className="card-header">
+            <div>
+              <h3 className="card-title">Today's schedule</h3>
+              <div style={{ fontSize: 11.5, color: 'var(--text-muted)', marginTop: 2 }}>Wed, Apr 29 · Dr. Patel & Dr. Okafor</div>
+            </div>
+            <div className="segment">
+              <button className="active">Day</button>
+              <button>Week</button>
+              <button>Month</button>
+            </div>
+          </div>
+          <div>
+            {appts.map((a, i) => (
+              <div key={i} onClick={() => go('patient', a.id)} style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '12px 20px', borderBottom: i < appts.length - 1 ? '1px solid var(--border)' : 'none', cursor: 'pointer' }}>
+                <div style={{ width: 60, flexShrink: 0 }}>
+                  <div className="mono" style={{ fontSize: 13, fontWeight: 600 }}>{a.time}</div>
+                  <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-dim)' }}>{a.dur} min</div>
+                </div>
+                <div style={{ width: 3, height: 36, background: a.kind === 'urgent' ? 'var(--danger)' : a.kind === 'followup' ? 'var(--info)' : 'var(--accent)', borderRadius: 2 }} />
+                <div className="avatar avatar-sm" style={{ width: 32, height: 32, fontSize: 11 }}>
+                  {a.patient.split(' ').map(n => n[0]).join('')}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13.5, fontWeight: 500 }}>{a.patient}</div>
+                  <div style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{a.reason} · {a.provider} · {a.room}</div>
+                </div>
+                <span className={`badge ${a.status === 'In room' ? 'badge-info' : a.status === 'Checked in' ? 'badge-success' : 'badge-neutral'}`}>{a.status}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Right column: alerts + week chart */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
+          <div className="card">
+            <div className="card-header">
+              <h3 className="card-title">Needs attention</h3>
+              <span className="badge badge-warn">5</span>
+            </div>
+            <div>
+              {[
+                { icon: 'AlertTriangle', tone: 'urgent', who: 'James Whitaker', what: 'BP 142/94 — above target', when: '20 min ago', id: 'MH-10341' },
+                { icon: 'Beaker', tone: 'watch', who: 'Eleanor Chen', what: 'A1c result requires review', when: '1h ago', id: 'MH-10042' },
+                { icon: 'Pill', tone: 'watch', who: 'Robert Kim', what: 'Refill request: Tiotropium', when: '2h ago', id: 'MH-10744' },
+                { icon: 'Mail', tone: 'normal', who: 'Marcus Rivera', what: 'Sent inhaler technique question', when: '3h ago', id: 'MH-10118' },
+              ].map((a, i, arr) => {
+                const Ic = window.MIcons[a.icon];
+                const tone = a.tone === 'urgent' ? '#ef4444' : a.tone === 'watch' ? '#f59e0b' : '#3b82f6';
+                return (
+                  <div key={i} onClick={() => go('patient', a.id)} style={{ display: 'flex', gap: 10, padding: '12px 16px', borderBottom: i < arr.length - 1 ? '1px solid var(--border)' : 'none', cursor: 'pointer' }}>
+                    <div style={{ width: 28, height: 28, borderRadius: 8, background: a.tone === 'urgent' ? 'var(--danger-soft)' : a.tone === 'watch' ? 'var(--warn-soft)' : 'var(--info-soft)', display: 'grid', placeItems: 'center', flexShrink: 0 }}>
+                      <Ic size={14} stroke={tone} />
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 12.5, fontWeight: 500 }}>{a.who}</div>
+                      <div style={{ fontSize: 11.5, color: 'var(--text-muted)' }}>{a.what}</div>
+                    </div>
+                    <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>{a.when}</div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="card card-pad">
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 14 }}>
+              <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: 0 }}>This week's volume</h3>
+              <span className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>112 visits</span>
+            </div>
+            <svg viewBox="0 0 280 100" style={{ width: '100%', height: 100 }}>
+              {week.map((d, i) => {
+                const max = Math.max(...week.map(w => w.visits)) || 1;
+                const h = (d.visits / max) * 70;
+                const x = 20 + i * 36;
+                return (
+                  <g key={i}>
+                    <rect x={x} y={80 - h} width="22" height={h} fill="var(--accent)" rx="3" opacity={i === 2 ? 1 : 0.55} />
+                    <text x={x + 11} y="94" textAnchor="middle" fontSize="9" fill="var(--text-dim)" fontFamily="var(--font-mono)">{d.d}</text>
+                    <text x={x + 11} y={76 - h} textAnchor="middle" fontSize="9" fill="var(--text-muted)" fontFamily="var(--font-mono)">{d.visits || ''}</text>
+                  </g>
+                );
+              })}
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom: recent patients */}
+      <div className="card">
+        <div className="card-header">
+          <h3 className="card-title">Recently seen patients</h3>
+          <button className="btn btn-ghost btn-sm" onClick={() => go('patients')}>All patients</button>
+        </div>
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table">
+            <thead>
+              <tr><th>Patient</th><th>MRN</th><th>Last visit</th><th>Conditions</th><th>Risk</th><th>Status</th><th>Next appt</th></tr>
+            </thead>
+            <tbody>
+              {patients.slice(0, 6).map(p => (
+                <tr key={p.id} onClick={() => go('patient', p.id)}>
+                  <td>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <div className="avatar avatar-sm" style={{ width: 28, height: 28, fontSize: 10 }}>{p.name.split(' ').map(n => n[0]).join('')}</div>
+                      <div>
+                        <div style={{ fontWeight: 500 }}>{p.name}</div>
+                        <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>{p.age} {p.sex} · {p.primary}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{p.mrn}</td>
+                  <td>{p.lastSeen}</td>
+                  <td style={{ fontSize: 12, color: 'var(--text-muted)' }}>{p.conditions.slice(0, 2).join(', ') || '—'}</td>
+                  <td><span className={`badge ${p.risk === 'High' ? 'badge-danger' : p.risk === 'Moderate' ? 'badge-warn' : 'badge-success'}`}>{p.risk}</span></td>
+                  <td><span className={`badge ${p.status === 'Stable' ? 'pill-stable' : p.status === 'Watch' ? 'pill-watch' : 'pill-urgent'}`} style={{ background: p.status === 'Stable' ? 'var(--success-soft)' : p.status === 'Watch' ? 'var(--warn-soft)' : 'var(--danger-soft)' }}>{p.status}</span></td>
+                  <td className="mono" style={{ fontSize: 12 }}>{p.nextAppt}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.MDashboardScreen = MDashboardScreen;

--- a/medic_plus/public/daystar-health/meridian-data.jsx
+++ b/medic_plus/public/daystar-health/meridian-data.jsx
@@ -1,0 +1,62 @@
+// Meridian Health — mock data
+const PATIENTS = [
+  { id: 'MH-10042', mrn: '04287-119', name: 'Eleanor Chen', dob: '1964-03-14', age: 62, sex: 'F', phone: '(415) 555-0142', email: 'e.chen@email.co', insurance: 'BlueCross PPO', primary: 'Dr. Patel', status: 'Stable', risk: 'Low', lastSeen: 'Mar 18, 2026', nextAppt: 'May 02, 2026', conditions: ['Hypertension', 'Type 2 Diabetes'], allergies: ['Penicillin'], meds: 4, vitals: { bp: '128/82', hr: 72, spo2: 98, weight: '142 lb', bmi: 24.1 } },
+  { id: 'MH-10118', mrn: '04287-220', name: 'Marcus Rivera', dob: '1981-09-02', age: 44, sex: 'M', phone: '(212) 555-0188', email: 'm.rivera@email.co', insurance: 'Aetna HMO', primary: 'Dr. Okafor', status: 'Watch', risk: 'Moderate', lastSeen: 'Apr 21, 2026', nextAppt: 'Apr 30, 2026', conditions: ['Asthma', 'Seasonal allergies'], allergies: ['Sulfa drugs'], meds: 2, vitals: { bp: '118/76', hr: 78, spo2: 96, weight: '186 lb', bmi: 25.8 } },
+  { id: 'MH-10256', mrn: '04287-331', name: 'Priya Nair', dob: '1992-11-28', age: 33, sex: 'F', phone: '(503) 555-0166', email: 'p.nair@email.co', insurance: 'Kaiser', primary: 'Dr. Patel', status: 'Stable', risk: 'Low', lastSeen: 'Apr 10, 2026', nextAppt: 'Oct 15, 2026', conditions: ['Migraine'], allergies: [], meds: 1, vitals: { bp: '110/70', hr: 66, spo2: 99, weight: '128 lb', bmi: 22.4 } },
+  { id: 'MH-10341', mrn: '04287-409', name: 'James Whitaker', dob: '1958-06-19', age: 67, sex: 'M', phone: '(617) 555-0190', email: 'j.whitaker@email.co', insurance: 'Medicare + Supp', primary: 'Dr. Okafor', status: 'Urgent', risk: 'High', lastSeen: 'Apr 27, 2026', nextAppt: 'Apr 29, 2026', conditions: ['CHF', 'Atrial fibrillation', 'Type 2 Diabetes'], allergies: ['Codeine', 'Latex'], meds: 7, vitals: { bp: '142/94', hr: 88, spo2: 94, weight: '218 lb', bmi: 28.7 } },
+  { id: 'MH-10488', mrn: '04287-512', name: 'Sofia Lindqvist', dob: '1995-02-07', age: 31, sex: 'F', phone: '(404) 555-0123', email: 's.lindqvist@email.co', insurance: 'United HC', primary: 'Dr. Patel', status: 'Stable', risk: 'Low', lastSeen: 'Mar 04, 2026', nextAppt: 'Sep 04, 2026', conditions: ['Hypothyroidism'], allergies: [], meds: 1, vitals: { bp: '116/72', hr: 68, spo2: 99, weight: '136 lb', bmi: 21.9 } },
+  { id: 'MH-10527', mrn: '04287-604', name: 'Daniel Osei', dob: '1976-12-11', age: 49, sex: 'M', phone: '(312) 555-0177', email: 'd.osei@email.co', insurance: 'Cigna PPO', primary: 'Dr. Okafor', status: 'Watch', risk: 'Moderate', lastSeen: 'Apr 19, 2026', nextAppt: 'May 14, 2026', conditions: ['Hyperlipidemia'], allergies: [], meds: 2, vitals: { bp: '132/86', hr: 74, spo2: 97, weight: '198 lb', bmi: 27.1 } },
+  { id: 'MH-10612', mrn: '04287-718', name: 'Aisha Patel', dob: '1988-04-22', age: 38, sex: 'F', phone: '(305) 555-0102', email: 'a.patel@email.co', insurance: 'Aetna PPO', primary: 'Dr. Patel', status: 'Stable', risk: 'Low', lastSeen: 'Feb 12, 2026', nextAppt: 'Aug 12, 2026', conditions: [], allergies: ['Shellfish'], meds: 0, vitals: { bp: '108/68', hr: 64, spo2: 99, weight: '124 lb', bmi: 22.0 } },
+  { id: 'MH-10744', mrn: '04287-822', name: 'Robert Kim', dob: '1949-08-30', age: 76, sex: 'M', phone: '(206) 555-0145', email: 'r.kim@email.co', insurance: 'Medicare', primary: 'Dr. Okafor', status: 'Watch', risk: 'High', lastSeen: 'Apr 24, 2026', nextAppt: 'May 06, 2026', conditions: ['COPD', 'Hypertension'], allergies: [], meds: 5, vitals: { bp: '138/88', hr: 82, spo2: 93, weight: '162 lb', bmi: 23.4 } },
+  { id: 'MH-10891', mrn: '04287-901', name: 'Lucia Mendoza', dob: '2001-01-15', age: 25, sex: 'F', phone: '(713) 555-0199', email: 'l.mendoza@email.co', insurance: 'BlueCross HMO', primary: 'Dr. Patel', status: 'Stable', risk: 'Low', lastSeen: 'Mar 28, 2026', nextAppt: 'Sep 28, 2026', conditions: [], allergies: [], meds: 0, vitals: { bp: '112/70', hr: 68, spo2: 99, weight: '130 lb', bmi: 22.1 } },
+  { id: 'MH-10923', mrn: '04287-988', name: 'Nathaniel Brooks', dob: '1972-05-08', age: 53, sex: 'M', phone: '(919) 555-0134', email: 'n.brooks@email.co', insurance: 'United HC', primary: 'Dr. Okafor', status: 'Stable', risk: 'Moderate', lastSeen: 'Apr 02, 2026', nextAppt: 'Jul 02, 2026', conditions: ['Anxiety', 'Insomnia'], allergies: ['Iodine'], meds: 3, vitals: { bp: '124/80', hr: 76, spo2: 98, weight: '178 lb', bmi: 25.5 } },
+];
+
+const TODAY_APPTS = [
+  { time: '08:00', dur: 30, patient: 'Eleanor Chen', id: 'MH-10042', reason: 'Annual physical', provider: 'Dr. Patel', room: 'Room 3', status: 'Checked in', kind: 'standard' },
+  { time: '08:45', dur: 20, patient: 'Marcus Rivera', id: 'MH-10118', reason: 'Asthma follow-up', provider: 'Dr. Okafor', room: 'Room 1', status: 'In room', kind: 'followup' },
+  { time: '09:30', dur: 45, patient: 'James Whitaker', id: 'MH-10341', reason: 'CHF management', provider: 'Dr. Okafor', room: 'Room 2', status: 'Scheduled', kind: 'urgent' },
+  { time: '10:30', dur: 30, patient: 'Daniel Osei', id: 'MH-10527', reason: 'Lipid panel review', provider: 'Dr. Okafor', room: 'Room 1', status: 'Scheduled', kind: 'standard' },
+  { time: '11:15', dur: 20, patient: 'Lucia Mendoza', id: 'MH-10891', reason: 'New patient intake', provider: 'Dr. Patel', room: 'Room 4', status: 'Scheduled', kind: 'standard' },
+  { time: '13:00', dur: 30, patient: 'Robert Kim', id: 'MH-10744', reason: 'COPD review', provider: 'Dr. Okafor', room: 'Room 2', status: 'Scheduled', kind: 'followup' },
+  { time: '14:00', dur: 20, patient: 'Sofia Lindqvist', id: 'MH-10488', reason: 'Thyroid labs', provider: 'Dr. Patel', room: 'Room 3', status: 'Scheduled', kind: 'standard' },
+  { time: '15:30', dur: 30, patient: 'Nathaniel Brooks', id: 'MH-10923', reason: 'Med review', provider: 'Dr. Okafor', room: 'Room 1', status: 'Scheduled', kind: 'standard' },
+];
+
+const VISITS_FOR = (id) => [
+  { date: 'Apr 21, 2026', type: 'Office visit', provider: 'Dr. Patel', reason: 'Routine follow-up', notes: 'BP within target. Continue current regimen.' },
+  { date: 'Feb 14, 2026', type: 'Telehealth', provider: 'Dr. Patel', reason: 'Medication check-in', notes: 'Tolerating metformin well. No GI side effects.' },
+  { date: 'Dec 03, 2025', type: 'Office visit', provider: 'Dr. Patel', reason: 'Annual physical', notes: 'Comprehensive exam. Labs ordered. Flu vaccine administered.' },
+  { date: 'Aug 18, 2025', type: 'Office visit', provider: 'Dr. Okafor (covering)', reason: 'Acute sinusitis', notes: 'Z-pack 5-day course. Symptom resolution expected within 48-72h.' },
+];
+
+const LABS_FOR = (id) => [
+  { name: 'A1c', value: '6.8', unit: '%', range: '< 7.0', status: 'Normal', date: 'Apr 21' },
+  { name: 'Glucose, fasting', value: '118', unit: 'mg/dL', range: '70-99', status: 'High', date: 'Apr 21' },
+  { name: 'LDL cholesterol', value: '128', unit: 'mg/dL', range: '< 100', status: 'High', date: 'Apr 21' },
+  { name: 'HDL cholesterol', value: '52', unit: 'mg/dL', range: '> 40', status: 'Normal', date: 'Apr 21' },
+  { name: 'Creatinine', value: '0.9', unit: 'mg/dL', range: '0.6-1.2', status: 'Normal', date: 'Apr 21' },
+  { name: 'TSH', value: '2.4', unit: 'mIU/L', range: '0.4-4.0', status: 'Normal', date: 'Apr 21' },
+];
+
+const MEDS_FOR = (id) => [
+  { name: 'Lisinopril', dose: '10 mg', freq: 'Once daily', start: 'Jan 2024', refills: 3, status: 'Active', class: 'ACE inhibitor' },
+  { name: 'Metformin', dose: '500 mg', freq: 'Twice daily with meals', start: 'Jun 2023', refills: 2, status: 'Active', class: 'Antidiabetic' },
+  { name: 'Atorvastatin', dose: '20 mg', freq: 'Once daily, evening', start: 'Mar 2024', refills: 5, status: 'Active', class: 'Statin' },
+  { name: 'Aspirin', dose: '81 mg', freq: 'Once daily', start: 'Jan 2024', refills: 11, status: 'Active', class: 'Antiplatelet' },
+];
+
+const VITALS_TREND_FOR = (id) => ({
+  bp_sys: [136, 134, 132, 138, 135, 130, 128, 132, 130, 128, 126, 128],
+  bp_dia: [88, 86, 84, 90, 86, 82, 82, 84, 82, 80, 80, 82],
+  weight: [148, 147, 146, 145, 145, 144, 143, 143, 142, 142, 142, 142],
+  hr: [78, 76, 74, 80, 76, 72, 72, 74, 72, 70, 70, 72],
+});
+
+const NOTES_FOR = (id) => [
+  { author: 'Dr. Patel', when: 'Apr 21, 2026', body: 'Patient reports good adherence to current regimen. BP log shows 24-hour averages within target. Reviewed lifestyle modifications and reinforced importance of low-sodium diet. Plan: continue current meds, follow up in 6 weeks with home BP log.' },
+  { author: 'RN Cortez', when: 'Apr 21, 2026', body: 'Vitals taken. Patient denies CP, SOB, dizziness. No new concerns reported.' },
+  { author: 'Dr. Patel', when: 'Feb 14, 2026', body: 'Telehealth check-in. Discussed metformin tolerance — patient reports occasional mild GI but improving. No need to adjust dose at this time.' },
+];
+
+window.MH_DATA = { PATIENTS, TODAY_APPTS, VISITS_FOR, LABS_FOR, MEDS_FOR, VITALS_TREND_FOR, NOTES_FOR };

--- a/medic_plus/public/daystar-health/meridian-icons.jsx
+++ b/medic_plus/public/daystar-health/meridian-icons.jsx
@@ -1,0 +1,30 @@
+// Meridian icons — extends Daystar icon set
+const MIcon = ({ d, children, size = 18, fill = 'none', stroke = 'currentColor', strokeWidth = 1.75, ...props }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke={stroke} strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" {...props}>
+    {d ? <path d={d} /> : children}
+  </svg>
+);
+
+const MeridianLogo = ({ size = 22 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+    <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#mhg)" />
+    <path d="M5 14 L8 14 L10 10 L13 16 L15 12 L19 12" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+    <defs>
+      <linearGradient id="mhg" x1="0" y1="0" x2="24" y2="24">
+        <stop offset="0" stopColor="#3b82f6" />
+        <stop offset="1" stopColor="#2563eb" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+
+window.MIcons = {
+  ...window.Icons,
+  Logo: MeridianLogo,
+  Stethoscope: (p) => <MIcon {...p}><path d="M5 3 V10 C5 13 7 15 10 15 C13 15 15 13 15 10 V3" /><path d="M3 3 H7 M13 3 H17" /><path d="M10 15 V18 C10 20 12 21 14 21 C16 21 18 20 18 18 V16" /><circle cx="18" cy="14" r="2" /></MIcon>,
+  Heart: (p) => <MIcon {...p}><path d="M12 21 C7 17 3 13 3 9 C3 6 5 4 8 4 C10 4 11 5 12 7 C13 5 14 4 16 4 C19 4 21 6 21 9 C21 13 17 17 12 21 Z" /></MIcon>,
+  Pill: (p) => <MIcon {...p}><rect x="3" y="9" width="18" height="6" rx="3" transform="rotate(-30 12 12)" /><line x1="9" y1="6" x2="15" y2="18" /></MIcon>,
+  ClipBoard: (p) => <MIcon {...p}><rect x="6" y="4" width="12" height="17" rx="2" /><rect x="9" y="2" width="6" height="3" rx="1" /><path d="M9 11 H15 M9 14 H15 M9 17 H13" /></MIcon>,
+  Beaker: (p) => <MIcon {...p}><path d="M9 3 V10 L4 19 C3.5 20 4 21 5 21 H19 C20 21 20.5 20 20 19 L15 10 V3" /><path d="M8 3 H16" /><path d="M6 16 H18" /></MIcon>,
+  Activity: (p) => <MIcon {...p}><path d="M3 12 H7 L9 6 L13 18 L15 12 L17 14 H21" /></MIcon>,
+};

--- a/medic_plus/public/daystar-health/meridian-layout.jsx
+++ b/medic_plus/public/daystar-health/meridian-layout.jsx
@@ -1,0 +1,108 @@
+// Meridian shared layout
+const { useState: mUseState, useMemo: mUseMemo, useEffect: mUseEffect } = React;
+
+function MSidebar({ route, go }) {
+  const items = [
+    { key: 'dashboard', icon: 'Home', label: 'Today' },
+    { key: 'appointments', icon: 'Calendar', label: 'Appointments', count: 12 },
+    { key: 'patients', icon: 'Users', label: 'Patients' },
+    { key: 'records', icon: 'ClipBoard', label: 'Medical Records' },
+    { key: 'labs', icon: 'Beaker', label: 'Labs & Imaging' },
+    { key: 'medications', icon: 'Pill', label: 'Prescriptions' },
+    { key: 'billing', icon: 'Tag', label: 'Billing & Claims' },
+    { key: 'practice', icon: 'Building', label: 'Practice' },
+  ];
+  const Logo = window.MIcons.Logo;
+  return (
+    <aside className="sidebar">
+      <div className="sidebar-brand">
+        <Logo size={22} />
+        <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.1 }}>
+          <span style={{ fontSize: 14, fontWeight: 600, letterSpacing: '-0.01em' }}>Daystar</span>
+          <span style={{ fontSize: 10.5, color: 'var(--text-dim)', letterSpacing: '0.06em', textTransform: 'uppercase', fontWeight: 500 }}>Health</span>
+        </div>
+        <div style={{ marginLeft: 'auto', width: 22, height: 22, display: 'grid', placeItems: 'center', borderRadius: 6, color: 'var(--text-dim)' }}>
+          <window.MIcons.ChevronLeft size={14} />
+        </div>
+      </div>
+
+      <div className="sidebar-nav">
+        <div className="sidebar-section">Today</div>
+        {items.slice(0, 2).map(it => {
+          const Ic = window.MIcons[it.icon];
+          return (
+            <button key={it.key} className={`nav-item ${route === it.key ? 'active' : ''}`} onClick={() => go(it.key)}>
+              <Ic size={17} /><span>{it.label}</span>
+              {it.count && <span style={{ marginLeft: 'auto', fontSize: 11, fontFamily: 'var(--font-mono)', background: 'var(--accent-soft)', padding: '1px 6px', borderRadius: 4, color: 'var(--accent-text)', fontWeight: 500 }}>{it.count}</span>}
+            </button>
+          );
+        })}
+        <div className="sidebar-section">Care</div>
+        {items.slice(2, 6).map(it => {
+          const Ic = window.MIcons[it.icon];
+          return (
+            <button key={it.key} className={`nav-item ${route === it.key ? 'active' : ''}`} onClick={() => go(it.key)}>
+              <Ic size={17} /><span>{it.label}</span>
+            </button>
+          );
+        })}
+        <div className="sidebar-section">Practice</div>
+        {items.slice(6).map(it => {
+          const Ic = window.MIcons[it.icon];
+          return (
+            <button key={it.key} className={`nav-item ${route === it.key ? 'active' : ''}`} onClick={() => go(it.key)}>
+              <Ic size={17} /><span>{it.label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ padding: 12, borderTop: '1px solid var(--border)' }}>
+        <button className="nav-item" onClick={() => go('profile')}>
+          <window.MIcons.Settings size={17} /><span>Account</span>
+        </button>
+        <button className="nav-item" onClick={() => go('login')}>
+          <window.MIcons.Logout size={17} /><span>Sign out</span>
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function MTopbar({ go, crumbs = [] }) {
+  return (
+    <div className="topbar">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--text-muted)' }}>
+        {crumbs.map((c, i) => (
+          <React.Fragment key={i}>
+            <button onClick={c.go} style={{ background: 'none', border: 'none', color: i === crumbs.length - 1 ? 'var(--text)' : 'var(--text-muted)', fontWeight: i === crumbs.length - 1 ? 500 : 400, fontSize: 13 }}>{c.label}</button>
+            {i < crumbs.length - 1 && <window.MIcons.ChevronRight size={12} />}
+          </React.Fragment>
+        ))}
+      </div>
+      <div className="search" style={{ marginLeft: 24, width: 380 }}>
+        <window.MIcons.Search size={15} />
+        <input placeholder="Search patients, MRN, appointments…" />
+        <kbd>⌘K</kbd>
+      </div>
+      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
+        <button className="btn btn-secondary btn-sm"><window.MIcons.Plus size={14} /> New visit</button>
+        <button className="btn btn-ghost btn-sm" style={{ width: 36, padding: 0 }}>
+          <window.MIcons.Bell size={17} />
+        </button>
+        <div style={{ width: 1, height: 20, background: 'var(--border)', margin: '0 6px' }} />
+        <button onClick={() => go('profile')} style={{ display: 'flex', alignItems: 'center', gap: 8, background: 'transparent', border: 'none', padding: '4px 8px 4px 4px', borderRadius: 8, cursor: 'pointer' }}>
+          <div className="avatar avatar-sm" style={{ width: 28, height: 28, fontSize: 11 }}>SP</div>
+          <div style={{ textAlign: 'left', lineHeight: 1.15 }}>
+            <div style={{ fontSize: 12.5, fontWeight: 500 }}>Dr. S. Patel</div>
+            <div style={{ fontSize: 10.5, color: 'var(--text-dim)' }}>Family Medicine</div>
+          </div>
+          <window.MIcons.ChevronDown size={13} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+window.MSidebar = MSidebar;
+window.MTopbar = MTopbar;

--- a/medic_plus/public/daystar-health/meridian-patient.jsx
+++ b/medic_plus/public/daystar-health/meridian-patient.jsx
@@ -1,0 +1,294 @@
+// Patient detail
+function MPatientScreen({ go, patientId }) {
+  const p = window.MH_DATA.PATIENTS.find(x => x.id === patientId) || window.MH_DATA.PATIENTS[0];
+  const [tab, setTab] = mUseState('overview');
+  const visits = window.MH_DATA.VISITS_FOR(p.id);
+  const labs = window.MH_DATA.LABS_FOR(p.id);
+  const meds = window.MH_DATA.MEDS_FOR(p.id);
+  const notes = window.MH_DATA.NOTES_FOR(p.id);
+  const trend = window.MH_DATA.VITALS_TREND_FOR(p.id);
+
+  const tabs = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'visits', label: 'Visits', count: visits.length },
+    { id: 'vitals', label: 'Vitals' },
+    { id: 'medications', label: 'Medications', count: meds.length },
+    { id: 'labs', label: 'Labs', count: labs.length },
+    { id: 'notes', label: 'Notes', count: notes.length },
+  ];
+
+  return (
+    <div className="page fade-in">
+      {/* Header */}
+      <div style={{ display: 'flex', gap: 18, alignItems: 'flex-start', marginBottom: 20 }}>
+        <div className="avatar" style={{ width: 64, height: 64, fontSize: 22, borderRadius: 16 }}>
+          {p.name.split(' ').map(n => n[0]).join('')}
+        </div>
+        <div style={{ flex: 1 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
+            <h1 style={{ fontSize: 22, fontWeight: 600, margin: 0, letterSpacing: '-0.02em' }}>{p.name}</h1>
+            <span className={`badge ${p.status === 'Stable' ? 'badge-success' : p.status === 'Watch' ? 'badge-warn' : 'badge-danger'}`}>{p.status}</span>
+            <span className={`badge ${p.risk === 'High' ? 'badge-danger' : p.risk === 'Moderate' ? 'badge-warn' : 'badge-neutral'}`}>{p.risk} risk</span>
+            {p.allergies.length > 0 && <span className="badge badge-danger" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><window.MIcons.AlertTriangle size={11} /> Allergy alert</span>}
+          </div>
+          <div style={{ display: 'flex', gap: 18, fontSize: 12.5, color: 'var(--text-muted)', flexWrap: 'wrap' }}>
+            <span><span className="mono">{p.mrn}</span></span>
+            <span>{p.age} yrs · {p.sex}</span>
+            <span>DOB {p.dob}</span>
+            <span>{p.insurance}</span>
+            <span>PCP: {p.primary}</span>
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn btn-secondary btn-sm"><window.MIcons.Mail size={14} /> Message</button>
+          <button className="btn btn-secondary btn-sm"><window.MIcons.Calendar size={14} /> Schedule</button>
+          <button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> Start visit</button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="tabs" style={{ marginBottom: 'var(--gap)' }}>
+        {tabs.map(t => (
+          <button key={t.id} className={`tab ${tab === t.id ? 'active' : ''}`} onClick={() => setTab(t.id)}>
+            {t.label}{t.count != null && <span style={{ fontSize: 11, color: 'var(--text-dim)', marginLeft: 6 }}>{t.count}</span>}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'overview' && (
+        <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 'var(--gap)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
+            {/* Vitals snapshot */}
+            <div className="card card-pad">
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 14 }}>
+                <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: 0 }}>Latest vitals</h3>
+                <span style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>Recorded Apr 21, 2026</span>
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 14 }}>
+                {[
+                  { label: 'BP', value: p.vitals.bp, unit: 'mmHg', tone: p.vitals.bp.split('/')[0] > 130 ? 'warn' : 'ok' },
+                  { label: 'HR', value: p.vitals.hr, unit: 'bpm', tone: 'ok' },
+                  { label: 'SpO₂', value: p.vitals.spo2, unit: '%', tone: p.vitals.spo2 < 95 ? 'warn' : 'ok' },
+                  { label: 'Weight', value: p.vitals.weight, unit: '', tone: 'ok' },
+                  { label: 'BMI', value: p.vitals.bmi, unit: '', tone: p.vitals.bmi > 25 ? 'warn' : 'ok' },
+                ].map((v, i) => (
+                  <div key={i} style={{ paddingLeft: i > 0 ? 14 : 0, borderLeft: i > 0 ? '1px solid var(--border)' : 'none' }}>
+                    <div style={{ fontSize: 11, color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>{v.label}</div>
+                    <div style={{ fontSize: 22, fontWeight: 600, fontFamily: 'var(--font-mono)', letterSpacing: '-0.02em', color: v.tone === 'warn' ? '#b45309' : 'var(--text)' }}>{v.value}</div>
+                    <div style={{ fontSize: 10.5, color: 'var(--text-dim)' }}>{v.unit}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* BP trend */}
+            <div className="card card-pad">
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
+                <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: 0 }}>Blood pressure — last 12 visits</h3>
+                <div style={{ display: 'flex', gap: 12, fontSize: 11.5 }}>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><span style={{ width: 8, height: 8, borderRadius: 2, background: '#2563eb' }} />Systolic</span>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><span style={{ width: 8, height: 8, borderRadius: 2, background: '#94a3b8' }} />Diastolic</span>
+                </div>
+              </div>
+              <svg viewBox="0 0 480 160" style={{ width: '100%', height: 160 }}>
+                {/* gridlines */}
+                {[40, 60, 80, 100, 120].map((y, i) => (
+                  <g key={i}>
+                    <line x1="40" x2="470" y1={y} y2={y} stroke="var(--border)" strokeDasharray="2 3" />
+                    <text x="32" y={y + 3} textAnchor="end" fontSize="9" fill="var(--text-dim)" fontFamily="var(--font-mono)">{160 - y}</text>
+                  </g>
+                ))}
+                {/* target band */}
+                <rect x="40" y={160 - 130} width="430" height="20" fill="#10b981" opacity="0.08" />
+                {/* lines */}
+                {(() => {
+                  const sx = (i) => 40 + i * (430 / 11);
+                  const sy = (v) => 160 - v;
+                  const path = (arr) => arr.map((v, i) => `${i === 0 ? 'M' : 'L'} ${sx(i)} ${sy(v)}`).join(' ');
+                  return (
+                    <>
+                      <path d={path(trend.bp_sys)} fill="none" stroke="#2563eb" strokeWidth="2" />
+                      <path d={path(trend.bp_dia)} fill="none" stroke="#94a3b8" strokeWidth="2" />
+                      {trend.bp_sys.map((v, i) => <circle key={'s'+i} cx={sx(i)} cy={sy(v)} r="2.5" fill="#2563eb" />)}
+                      {trend.bp_dia.map((v, i) => <circle key={'d'+i} cx={sx(i)} cy={sy(v)} r="2.5" fill="#94a3b8" />)}
+                    </>
+                  );
+                })()}
+              </svg>
+            </div>
+
+            {/* Recent visits */}
+            <div className="card">
+              <div className="card-header"><h3 className="card-title">Recent visits</h3><button className="btn btn-ghost btn-sm" onClick={() => setTab('visits')}>All visits</button></div>
+              <div>
+                {visits.slice(0, 3).map((v, i) => (
+                  <div key={i} style={{ padding: '14px 20px', borderBottom: i < 2 ? '1px solid var(--border)' : 'none' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+                      <div style={{ fontSize: 13.5, fontWeight: 500 }}>{v.reason}</div>
+                      <div className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{v.date}</div>
+                    </div>
+                    <div style={{ fontSize: 11.5, color: 'var(--text-dim)', marginBottom: 6 }}>{v.type} · {v.provider}</div>
+                    <div style={{ fontSize: 12.5, color: 'var(--text-muted)' }}>{v.notes}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
+            {/* Contact */}
+            <div className="card card-pad">
+              <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 12px' }}>Contact</h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10, fontSize: 12.5 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Phone</span><span className="mono">{p.phone}</span></div>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Email</span><span>{p.email}</span></div>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Insurance</span><span>{p.insurance}</span></div>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Last seen</span><span className="mono">{p.lastSeen}</span></div>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Next appt</span><span className="mono" style={{ color: 'var(--accent-text)', fontWeight: 500 }}>{p.nextAppt}</span></div>
+              </div>
+            </div>
+
+            {/* Conditions */}
+            <div className="card card-pad">
+              <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 10px' }}>Active conditions</h3>
+              {p.conditions.length === 0 ? (
+                <div style={{ fontSize: 12.5, color: 'var(--text-dim)' }}>None on file.</div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {p.conditions.map((c, i) => (
+                    <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', background: 'var(--bg-subtle)', border: '1px solid var(--border)', borderRadius: 6, fontSize: 12.5 }}>
+                      <window.MIcons.Heart size={13} stroke="var(--accent)" />
+                      <span style={{ flex: 1 }}>{c}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Allergies */}
+            <div className="card card-pad">
+              <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 10px' }}>Allergies</h3>
+              {p.allergies.length === 0 ? (
+                <div style={{ fontSize: 12.5, color: 'var(--text-dim)' }}>NKDA — No known drug allergies.</div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {p.allergies.map((a, i) => (
+                    <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', background: 'var(--danger-soft)', borderRadius: 6, fontSize: 12.5, color: '#b91c1c' }}>
+                      <window.MIcons.AlertTriangle size={13} />
+                      <span style={{ flex: 1, fontWeight: 500 }}>{a}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {tab === 'visits' && (
+        <div className="card">
+          <div className="card-header"><h3 className="card-title">Visit history</h3><button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> New visit</button></div>
+          <div>
+            {visits.map((v, i) => (
+              <div key={i} style={{ padding: '16px 20px', borderBottom: i < visits.length - 1 ? '1px solid var(--border)' : 'none' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                  <div>
+                    <span style={{ fontSize: 14, fontWeight: 500 }}>{v.reason}</span>
+                    <span className="badge badge-neutral" style={{ marginLeft: 8 }}>{v.type}</span>
+                  </div>
+                  <div className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{v.date} · {v.provider}</div>
+                </div>
+                <div style={{ fontSize: 13, color: 'var(--text-muted)' }}>{v.notes}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {tab === 'vitals' && (
+        <div className="card card-pad">
+          <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 14px' }}>Vitals trends</h3>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--gap)' }}>
+            {[
+              { label: 'Heart rate (bpm)', data: trend.hr, color: '#ef4444' },
+              { label: 'Weight (lb)', data: trend.weight, color: '#8b5cf6' },
+            ].map((s, i) => (
+              <div key={i} className="card card-pad">
+                <h4 style={{ fontSize: 12.5, fontWeight: 500, margin: '0 0 10px', color: 'var(--text-muted)' }}>{s.label}</h4>
+                <window.Sparkline data={s.data} color={s.color} height={80} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {tab === 'medications' && (
+        <div className="card">
+          <div className="card-header"><h3 className="card-title">Active medications</h3><button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> Prescribe</button></div>
+          <table className="table">
+            <thead><tr><th>Medication</th><th>Dose</th><th>Frequency</th><th>Class</th><th>Started</th><th>Refills</th><th>Status</th></tr></thead>
+            <tbody>
+              {meds.map((m, i) => (
+                <tr key={i}>
+                  <td><div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><window.MIcons.Pill size={14} stroke="var(--accent)" /><span style={{ fontWeight: 500 }}>{m.name}</span></div></td>
+                  <td className="mono">{m.dose}</td>
+                  <td style={{ fontSize: 12.5 }}>{m.freq}</td>
+                  <td style={{ color: 'var(--text-muted)', fontSize: 12.5 }}>{m.class}</td>
+                  <td className="mono" style={{ fontSize: 12 }}>{m.start}</td>
+                  <td className="mono">{m.refills}</td>
+                  <td><span className="badge badge-success">{m.status}</span></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {tab === 'labs' && (
+        <div className="card">
+          <div className="card-header"><h3 className="card-title">Lab results — Apr 21, 2026</h3><button className="btn btn-secondary btn-sm"><window.MIcons.Download size={14} /> Export PDF</button></div>
+          <table className="table">
+            <thead><tr><th>Test</th><th style={{ textAlign: 'right' }}>Value</th><th>Unit</th><th>Reference</th><th>Status</th></tr></thead>
+            <tbody>
+              {labs.map((l, i) => (
+                <tr key={i}>
+                  <td style={{ fontWeight: 500 }}>{l.name}</td>
+                  <td className="mono" style={{ textAlign: 'right', fontWeight: 600, color: l.status === 'High' ? '#b45309' : l.status === 'Low' ? '#1d4ed8' : 'var(--text)' }}>{l.value}</td>
+                  <td style={{ fontSize: 12.5, color: 'var(--text-muted)' }}>{l.unit}</td>
+                  <td className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{l.range}</td>
+                  <td><span className={`badge ${l.status === 'Normal' ? 'badge-success' : l.status === 'High' ? 'badge-warn' : 'badge-info'}`}>{l.status}</span></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {tab === 'notes' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
+          <div className="card card-pad">
+            <textarea className="textarea" rows="3" placeholder="Add a clinical note…" style={{ marginBottom: 10 }} />
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+              <button className="btn btn-secondary btn-sm">Save draft</button>
+              <button className="btn btn-primary btn-sm">Sign & save</button>
+            </div>
+          </div>
+          {notes.map((n, i) => (
+            <div key={i} className="card card-pad">
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <div className="avatar avatar-sm" style={{ width: 26, height: 26, fontSize: 10 }}>{n.author.split(' ').map(s => s[0]).join('').slice(0, 2)}</div>
+                  <span style={{ fontSize: 13, fontWeight: 500 }}>{n.author}</span>
+                </div>
+                <span className="mono" style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{n.when}</span>
+              </div>
+              <div style={{ fontSize: 13, color: 'var(--text-muted)', lineHeight: 1.55 }}>{n.body}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+window.MPatientScreen = MPatientScreen;

--- a/medic_plus/public/daystar-health/meridian-patients.jsx
+++ b/medic_plus/public/daystar-health/meridian-patients.jsx
@@ -1,0 +1,152 @@
+// Patients listing
+function MPatientsScreen({ go }) {
+  const all = window.MH_DATA.PATIENTS;
+  const [query, setQuery] = mUseState('');
+  const [risk, setRisk] = mUseState('All');
+  const [status, setStatus] = mUseState('All');
+  const [provider, setProvider] = mUseState('All');
+  const [sort, setSort] = mUseState({ key: 'name', dir: 'asc' });
+  const [selected, setSelected] = mUseState(new Set());
+
+  const providers = ['All', ...Array.from(new Set(all.map(p => p.primary)))];
+
+  const filtered = mUseMemo(() => {
+    let r = all.filter(p => (
+      (!query || p.name.toLowerCase().includes(query.toLowerCase()) || p.mrn.includes(query) || p.id.toLowerCase().includes(query.toLowerCase())) &&
+      (risk === 'All' || p.risk === risk) &&
+      (status === 'All' || p.status === status) &&
+      (provider === 'All' || p.primary === provider)
+    ));
+    r.sort((a, b) => {
+      const av = a[sort.key], bv = b[sort.key];
+      if (typeof av === 'string') return sort.dir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+      return sort.dir === 'asc' ? av - bv : bv - av;
+    });
+    return r;
+  }, [all, query, risk, status, provider, sort]);
+
+  const toggleSort = (k) => setSort(s => s.key === k ? { key: k, dir: s.dir === 'asc' ? 'desc' : 'asc' } : { key: k, dir: 'asc' });
+  const SortHead = ({ k, children, align }) => (
+    <th onClick={() => toggleSort(k)} style={{ cursor: 'pointer', textAlign: align || 'left' }}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        {children}
+        {sort.key === k && (sort.dir === 'asc' ? <window.MIcons.Up size={11} /> : <window.MIcons.Down size={11} />)}
+      </span>
+    </th>
+  );
+
+  const toggleSel = (id) => {
+    const s = new Set(selected);
+    if (s.has(id)) s.delete(id); else s.add(id);
+    setSelected(s);
+  };
+
+  return (
+    <div className="page fade-in">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 20, gap: 16, flexWrap: 'wrap' }}>
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 4px', letterSpacing: '-0.02em' }}>Patients</h1>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{filtered.length} of {all.length} patients · 1,284 active in practice</p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btn btn-secondary btn-sm"><window.MIcons.Download size={14} /> Export</button>
+          <button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> Register patient</button>
+        </div>
+      </div>
+
+      <div className="card" style={{ marginBottom: 'var(--gap)' }}>
+        <div style={{ padding: 14, display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+          <div className="search" style={{ flex: 1, minWidth: 240 }}>
+            <window.MIcons.Search size={15} />
+            <input placeholder="Search by name, MRN, or ID…" value={query} onChange={e => setQuery(e.target.value)} />
+          </div>
+          <select className="select" style={{ width: 'auto', minWidth: 130 }} value={provider} onChange={e => setProvider(e.target.value)}>
+            {providers.map(p => <option key={p}>{p === 'All' ? 'All providers' : p}</option>)}
+          </select>
+          <select className="select" style={{ width: 'auto', minWidth: 110 }} value={risk} onChange={e => setRisk(e.target.value)}>
+            {['All', 'Low', 'Moderate', 'High'].map(r => <option key={r}>{r === 'All' ? 'All risk' : r}</option>)}
+          </select>
+          <select className="select" style={{ width: 'auto', minWidth: 110 }} value={status} onChange={e => setStatus(e.target.value)}>
+            {['All', 'Stable', 'Watch', 'Urgent'].map(s => <option key={s}>{s === 'All' ? 'All status' : s}</option>)}
+          </select>
+          <button className="btn btn-secondary btn-sm"><window.MIcons.Filter size={14} /> More</button>
+        </div>
+
+        {selected.size > 0 && (
+          <div style={{ padding: '10px 16px', background: 'var(--accent-soft)', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 12, fontSize: 13 }}>
+            <span style={{ fontWeight: 500, color: 'var(--accent-text)' }}>{selected.size} selected</span>
+            <button className="btn btn-secondary btn-sm">Send message</button>
+            <button className="btn btn-secondary btn-sm">Schedule</button>
+            <button className="btn btn-secondary btn-sm">Add to care plan</button>
+            <button onClick={() => setSelected(new Set())} className="btn btn-ghost btn-sm" style={{ marginLeft: 'auto' }}>Clear</button>
+          </div>
+        )}
+
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th style={{ width: 40 }}>
+                  <span className={`checkbox ${selected.size === filtered.length && filtered.length > 0 ? 'checked' : ''}`} onClick={() => setSelected(selected.size === filtered.length ? new Set() : new Set(filtered.map(p => p.id)))}>
+                    {selected.size === filtered.length && filtered.length > 0 && <window.MIcons.Check size={11} strokeWidth={3} />}
+                  </span>
+                </th>
+                <SortHead k="name">Patient</SortHead>
+                <SortHead k="mrn">MRN</SortHead>
+                <SortHead k="age" align="right">Age</SortHead>
+                <th>Conditions</th>
+                <th>Allergies</th>
+                <SortHead k="lastSeen">Last seen</SortHead>
+                <SortHead k="risk">Risk</SortHead>
+                <SortHead k="status">Status</SortHead>
+                <th style={{ width: 40 }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map(p => (
+                <tr key={p.id} onClick={() => go('patient', p.id)}>
+                  <td onClick={e => e.stopPropagation()}>
+                    <span className={`checkbox ${selected.has(p.id) ? 'checked' : ''}`} onClick={() => toggleSel(p.id)}>
+                      {selected.has(p.id) && <window.MIcons.Check size={11} strokeWidth={3} />}
+                    </span>
+                  </td>
+                  <td>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <div className="avatar avatar-sm" style={{ width: 32, height: 32, fontSize: 11 }}>{p.name.split(' ').map(n => n[0]).join('')}</div>
+                      <div>
+                        <div style={{ fontWeight: 500 }}>{p.name}</div>
+                        <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>{p.sex} · DOB {p.dob} · {p.primary}</div>
+                      </div>
+                    </div>
+                  </td>
+                  <td className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{p.mrn}</td>
+                  <td className="mono" style={{ textAlign: 'right' }}>{p.age}</td>
+                  <td style={{ fontSize: 12, color: 'var(--text-muted)' }}>{p.conditions.length === 0 ? <span style={{ color: 'var(--text-dim)' }}>—</span> : p.conditions.slice(0, 2).join(', ')}{p.conditions.length > 2 && <span style={{ color: 'var(--text-dim)' }}> +{p.conditions.length - 2}</span>}</td>
+                  <td>{p.allergies.length === 0 ? <span style={{ color: 'var(--text-dim)', fontSize: 12 }}>NKDA</span> : <span className="badge badge-danger">{p.allergies.length}</span>}</td>
+                  <td className="mono" style={{ fontSize: 12 }}>{p.lastSeen}</td>
+                  <td><span className={`badge ${p.risk === 'High' ? 'badge-danger' : p.risk === 'Moderate' ? 'badge-warn' : 'badge-success'}`}>{p.risk}</span></td>
+                  <td><span className={`badge ${p.status === 'Stable' ? 'badge-success' : p.status === 'Watch' ? 'badge-warn' : 'badge-danger'}`}>{p.status}</span></td>
+                  <td onClick={e => e.stopPropagation()}>
+                    <button className="btn btn-ghost btn-sm" style={{ width: 28, padding: 0 }}><window.MIcons.More size={16} /></button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 12, fontSize: 12.5, color: 'var(--text-muted)' }}>
+          <span>Rows per page</span>
+          <select className="select" style={{ width: 70, height: 28, fontSize: 12 }}><option>10</option><option>25</option></select>
+          <span style={{ marginLeft: 'auto' }}>1 – {filtered.length} of {filtered.length}</span>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <button className="btn btn-secondary btn-sm" style={{ width: 28, padding: 0 }}><window.MIcons.ChevronLeft size={14} /></button>
+            <button className="btn btn-secondary btn-sm" style={{ width: 28, padding: 0 }}><window.MIcons.ChevronRight size={14} /></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.MPatientsScreen = MPatientsScreen;

--- a/medic_plus/public/daystar-health/meridian-profile.jsx
+++ b/medic_plus/public/daystar-health/meridian-profile.jsx
@@ -1,0 +1,120 @@
+// Profile (provider account)
+function MProfileScreen({ go }) {
+  const [tab, setTab] = mUseState('account');
+  const [form, setForm] = mUseState({
+    firstName: 'Sanjay', lastName: 'Patel', email: 's.patel@daystarhealth.co',
+    phone: '(415) 555-0142', npi: '1234567890', specialty: 'Family Medicine',
+    title: 'Attending Physician',
+  });
+  const upd = (k, v) => setForm(f => ({ ...f, [k]: v }));
+
+  return (
+    <div className="page fade-in">
+      <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 4px', letterSpacing: '-0.02em' }}>Account settings</h1>
+      <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: '0 0 20px' }}>Manage your provider profile, sign-in, and preferences.</p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '220px 1fr', gap: 'var(--gap)' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {[
+            { id: 'account', label: 'Profile', icon: 'Users' },
+            { id: 'security', label: 'Sign-in & security', icon: 'Lock' },
+            { id: 'notifications', label: 'Notifications', icon: 'Bell' },
+          ].map(t => {
+            const Ic = window.MIcons[t.icon];
+            return (
+              <button key={t.id} className={`nav-item ${tab === t.id ? 'active' : ''}`} onClick={() => setTab(t.id)} style={{ marginBottom: 2 }}>
+                <Ic size={15} /><span>{t.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
+          {tab === 'account' && (
+            <>
+              <div className="card card-pad">
+                <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Profile photo</h3>
+                <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: '0 0 16px' }}>Shown to your team and on patient correspondence.</p>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+                  <div className="avatar" style={{ width: 72, height: 72, fontSize: 24, borderRadius: 18 }}>SP</div>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <button className="btn btn-secondary btn-sm">Upload new</button>
+                    <button className="btn btn-ghost btn-sm">Remove</button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="card card-pad">
+                <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 16px' }}>Provider information</h3>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
+                  <div className="field"><label className="label">First name</label><input className="input" value={form.firstName} onChange={e => upd('firstName', e.target.value)} /></div>
+                  <div className="field"><label className="label">Last name</label><input className="input" value={form.lastName} onChange={e => upd('lastName', e.target.value)} /></div>
+                  <div className="field"><label className="label">Title</label><input className="input" value={form.title} onChange={e => upd('title', e.target.value)} /></div>
+                  <div className="field"><label className="label">Specialty</label><input className="input" value={form.specialty} onChange={e => upd('specialty', e.target.value)} /></div>
+                  <div className="field"><label className="label">Work email</label><input className="input" type="email" value={form.email} onChange={e => upd('email', e.target.value)} /></div>
+                  <div className="field"><label className="label">Phone</label><input className="input" value={form.phone} onChange={e => upd('phone', e.target.value)} /></div>
+                  <div className="field"><label className="label">NPI number</label><input className="input mono" value={form.npi} onChange={e => upd('npi', e.target.value)} /></div>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18, paddingTop: 16, borderTop: '1px solid var(--border)' }}>
+                  <button className="btn btn-ghost btn-sm">Cancel</button>
+                  <button className="btn btn-primary btn-sm">Save changes</button>
+                </div>
+              </div>
+            </>
+          )}
+
+          {tab === 'security' && (
+            <>
+              <div className="card card-pad">
+                <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Password</h3>
+                <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: '0 0 16px' }}>Last changed 47 days ago. Practice policy requires rotation every 90 days.</p>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
+                  <div className="field"><label className="label">Current password</label><input className="input" type="password" defaultValue="••••••••" /></div>
+                  <div />
+                  <div className="field"><label className="label">New password</label><input className="input" type="password" /></div>
+                  <div className="field"><label className="label">Confirm new</label><input className="input" type="password" /></div>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18, paddingTop: 16, borderTop: '1px solid var(--border)' }}>
+                  <button className="btn btn-primary btn-sm">Update password</button>
+                </div>
+              </div>
+              <div className="card card-pad">
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <div>
+                    <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Two-factor authentication</h3>
+                    <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: 0 }}>Required for HIPAA compliance. Currently using authenticator app.</p>
+                  </div>
+                  <span className="badge badge-success">Enabled</span>
+                </div>
+              </div>
+            </>
+          )}
+
+          {tab === 'notifications' && (
+            <div className="card card-pad">
+              <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 16px' }}>Notification preferences</h3>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+                {[
+                  { label: 'Critical lab results', sub: 'Notify me immediately when a result is flagged critical', on: true },
+                  { label: 'New patient messages', sub: 'Patient portal messages requiring a response', on: true },
+                  { label: 'Refill requests', sub: 'Pharmacy and patient-initiated refill requests', on: true },
+                  { label: 'Daily schedule digest', sub: 'Email summary of tomorrow\'s appointments at 6 PM', on: false },
+                ].map((n, i, arr) => (
+                  <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingBottom: 14, borderBottom: i < arr.length - 1 ? '1px solid var(--border)' : 'none' }}>
+                    <div>
+                      <div style={{ fontSize: 13.5, fontWeight: 500 }}>{n.label}</div>
+                      <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>{n.sub}</div>
+                    </div>
+                    <div className={`switch ${n.on ? 'on' : ''}`}><div className="dot" /></div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.MProfileScreen = MProfileScreen;

--- a/medic_plus/public/daystar-health/meridian.css
+++ b/medic_plus/public/daystar-health/meridian.css
@@ -1,0 +1,70 @@
+/* Meridian Health overrides — teal accent on the same base system */
+:root {
+  --accent: #2563eb;
+  --accent-hover: #1d4ed8;
+  --accent-soft: oklch(0.96 0.04 250);
+  --accent-text: #1d4ed8;
+}
+[data-theme="dark"] {
+  --accent-soft: oklch(0.30 0.07 250);
+  --accent-text: #60a5fa;
+}
+.btn-primary {
+  background: linear-gradient(180deg, #3b82f6 0%, var(--accent) 100%);
+}
+.btn-primary:hover { background: linear-gradient(180deg, var(--accent) 0%, var(--accent-hover) 100%); }
+
+.auth-shell {
+  background:
+    radial-gradient(ellipse at top right, oklch(0.96 0.05 250) 0%, transparent 60%),
+    radial-gradient(ellipse at bottom left, oklch(0.97 0.03 220) 0%, transparent 60%),
+    var(--bg);
+}
+[data-theme="dark"] .auth-shell {
+  background:
+    radial-gradient(ellipse at top right, oklch(0.25 0.07 250) 0%, transparent 60%),
+    radial-gradient(ellipse at bottom left, oklch(0.22 0.04 220) 0%, transparent 60%),
+    var(--bg);
+}
+
+.avatar {
+  background: linear-gradient(135deg, #3b82f6, #2563eb);
+}
+
+/* Status pills specific to clinical workflows */
+.pill-stable { background: var(--success-soft); color: #047857; }
+.pill-watch { background: var(--warn-soft); color: #b45309; }
+.pill-urgent { background: var(--danger-soft); color: #b91c1c; }
+[data-theme="dark"] .pill-stable { color: #34d399; }
+[data-theme="dark"] .pill-watch { color: #fbbf24; }
+[data-theme="dark"] .pill-urgent { color: #f87171; }
+
+/* Calendar */
+.cal-grid {
+  display: grid;
+  grid-template-columns: 60px repeat(5, 1fr);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--surface);
+}
+.cal-cell {
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  min-height: 48px;
+  position: relative;
+  font-size: 11px;
+  padding: 4px 6px;
+}
+.cal-time { color: var(--text-dim); font-family: var(--font-mono); }
+.cal-event {
+  background: var(--accent-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+  padding: 4px 6px;
+  font-size: 11px;
+  margin-bottom: 2px;
+  cursor: pointer;
+}
+.cal-event.urgent { background: var(--danger-soft); border-left-color: var(--danger); color: #b91c1c; }
+.cal-event.followup { background: var(--info-soft); border-left-color: var(--info); }

--- a/medic_plus/public/daystar-health/parent-dashboard.jsx
+++ b/medic_plus/public/daystar-health/parent-dashboard.jsx
@@ -1,0 +1,270 @@
+// Dashboard
+function Sparkline({ data, color = 'var(--accent)', height = 56, fill = true }) {
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const w = 100;
+  const pts = data.map((v, i) => `${(i / (data.length - 1)) * w},${height - ((v - min) / range) * (height - 6) - 3}`).join(' ');
+  const area = `0,${height} ${pts} ${w},${height}`;
+  const id = `spk-${Math.random().toString(36).slice(2, 7)}`;
+  return (
+    <svg viewBox={`0 0 ${w} ${height}`} preserveAspectRatio="none" style={{ width: '100%', height }}>
+      {fill && <>
+        <defs>
+          <linearGradient id={id} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor={color} stopOpacity="0.18" />
+            <stop offset="1" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <polygon points={area} fill={`url(#${id})`} />
+      </>}
+      <polyline points={pts} fill="none" stroke={color} strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function StackBar({ values, colors, labels }) {
+  const total = values.reduce((a, b) => a + b, 0);
+  return (
+    <div>
+      <div style={{ display: 'flex', height: 8, borderRadius: 999, overflow: 'hidden', background: 'var(--bg-subtle)' }}>
+        {values.map((v, i) => (
+          <div key={i} style={{ width: `${(v / total) * 100}%`, background: colors[i] }} />
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: 14, marginTop: 12, flexWrap: 'wrap' }}>
+        {values.map((v, i) => (
+          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: colors[i] }} />
+            <span style={{ color: 'var(--text-muted)' }}>{labels[i]}</span>
+            <span className="mono" style={{ fontWeight: 500 }}>{v}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DashboardScreen({ go }) {
+  const [range, setRange] = useState('30D');
+  const products = window.DSM_DATA.PRODUCTS;
+  const lowStock = products.filter(p => p.status === 'Low stock' || p.status === 'Out of stock');
+
+  const kpis = [
+    { label: 'Total inventory value', value: '$2.84M', delta: '+4.2%', up: true, trend: [62, 65, 68, 64, 70, 72, 75, 73, 78, 80, 82, 85] },
+    { label: 'Units on hand', value: '14,762', delta: '+1.8%', up: true, trend: [50, 52, 55, 58, 56, 60, 62, 64, 63, 66, 68, 70] },
+    { label: '30-day sell-through', value: '68.4%', delta: '+6.1%', up: true, trend: [40, 45, 48, 52, 55, 58, 60, 62, 65, 66, 68, 68] },
+    { label: 'Low stock SKUs', value: '24', delta: '+3', up: false, trend: [10, 12, 14, 13, 16, 18, 20, 19, 22, 21, 23, 24] },
+  ];
+
+  // Sales activity chart
+  const weeks = [
+    { w: 'W1', sales: 28200, units: 1840 },
+    { w: 'W2', sales: 31400, units: 2010 },
+    { w: 'W3', sales: 26800, units: 1720 },
+    { w: 'W4', sales: 38900, units: 2480 },
+    { w: 'W5', sales: 42100, units: 2680 },
+    { w: 'W6', sales: 39400, units: 2510 },
+    { w: 'W7', sales: 45800, units: 2920 },
+    { w: 'W8', sales: 48200, units: 3080 },
+  ];
+
+  return (
+    <div className="page fade-in">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 24, gap: 16, flexWrap: 'wrap' }}>
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 4px', letterSpacing: '-0.02em' }}>Dashboard</h1>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>Overview of inventory, sell-through, and replenishment across 4 stores.</p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <div className="segment">
+            {['7D', '30D', '90D', 'YTD'].map(r => (
+              <button key={r} className={range === r ? 'active' : ''} onClick={() => setRange(r)}>{r}</button>
+            ))}
+          </div>
+          <button className="btn btn-secondary btn-sm"><window.Icons.Download size={14} /> Export</button>
+          <button className="btn btn-primary btn-sm" onClick={() => go('products')}><window.Icons.Plus size={14} /> Add product</button>
+        </div>
+      </div>
+
+      {/* KPI tiles */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
+        {kpis.map((k, i) => (
+          <div key={i} className="kpi-tile">
+            <div className="kpi-label">{k.label}</div>
+            <div className="kpi-value">{k.value}</div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+              <span className={`kpi-delta ${k.up ? 'up' : 'down'}`}>
+                {k.up ? <window.Icons.Up /> : <window.Icons.Down />} {k.delta}
+              </span>
+              <div style={{ width: 80, opacity: 0.8 }}>
+                <Sparkline data={k.trend} color={k.up ? '#10b981' : '#ef4444'} height={28} />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Mid row */}
+      <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
+        {/* Sales activity */}
+        <div className="card">
+          <div className="card-header">
+            <div>
+              <h3 className="card-title">Sales activity</h3>
+              <div style={{ display: 'flex', gap: 24, marginTop: 8 }}>
+                <div>
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 2 }}>Revenue</div>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                    <span className="mono" style={{ fontSize: 20, fontWeight: 600 }}>$300,800</span>
+                    <span className="kpi-delta up"><window.Icons.Up /> 8.2%</span>
+                  </div>
+                </div>
+                <div>
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 2 }}>Units sold</div>
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                    <span className="mono" style={{ fontSize: 20, fontWeight: 600 }}>19,240</span>
+                    <span className="kpi-delta up"><window.Icons.Up /> 5.4%</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="card-pad" style={{ paddingTop: 8 }}>
+            <SalesChart weeks={weeks} />
+          </div>
+        </div>
+
+        {/* Inventory health */}
+        <div className="card">
+          <div className="card-header">
+            <h3 className="card-title">Inventory health</h3>
+            <button className="btn btn-ghost btn-sm" onClick={() => go('products')}>See all</button>
+          </div>
+          <div className="card-pad">
+            <div style={{ marginBottom: 18 }}>
+              <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>Total asset value</div>
+              <div className="mono" style={{ fontSize: 28, fontWeight: 600, letterSpacing: '-0.02em' }}>$2,841,920</div>
+            </div>
+            <StackBar
+              values={[78, 16, 6]}
+              colors={['#10b981', '#f59e0b', '#ef4444']}
+              labels={['In stock', 'Low stock', 'Out of stock']}
+            />
+            <div style={{ borderTop: '1px solid var(--border)', marginTop: 18, paddingTop: 14 }}>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 10, fontWeight: 500 }}>Needs replenishment</div>
+              {lowStock.slice(0, 3).map(p => (
+                <div key={p.id} onClick={() => go('product', p.id)} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid var(--border)', cursor: 'pointer' }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 12.5, fontWeight: 500, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.name}</div>
+                    <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-dim)' }}>{p.id}</div>
+                  </div>
+                  <span className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>Qty {p.stock}</span>
+                  <button className="btn btn-secondary btn-sm" onClick={(e) => { e.stopPropagation(); }}>Order</button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom row */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--gap)' }}>
+        <div className="card">
+          <div className="card-header">
+            <h3 className="card-title">Top movers — last 30 days</h3>
+            <button className="btn btn-ghost btn-sm">View all</button>
+          </div>
+          <div>
+            {products.slice(0, 5).map((p, i) => (
+              <div key={p.id} onClick={() => go('product', p.id)} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 20px', borderBottom: i < 4 ? '1px solid var(--border)' : 'none', cursor: 'pointer' }}>
+                <div className="placeholder-img" style={{ width: 40, height: 40, fontSize: 0 }}></div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 500 }}>{p.name}</div>
+                  <div style={{ fontSize: 11, color: 'var(--text-dim)', display: 'flex', gap: 8 }}>
+                    <span className="mono">{p.id}</span>
+                    <span>•</span>
+                    <span>{p.category}</span>
+                  </div>
+                </div>
+                <div style={{ width: 80 }}>
+                  <Sparkline data={p.trend} color="#10b981" height={26} />
+                </div>
+                <div style={{ textAlign: 'right' }}>
+                  <div className="mono" style={{ fontSize: 13, fontWeight: 500 }}>{p.sold30d.toLocaleString()}</div>
+                  <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>units</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card-header">
+            <h3 className="card-title">Open purchase orders</h3>
+            <button className="btn btn-ghost btn-sm">All POs</button>
+          </div>
+          <div>
+            {window.DSM_DATA.ORDERS.slice(0, 5).map((o, i) => (
+              <div key={o.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 20px', borderBottom: i < 4 ? '1px solid var(--border)' : 'none' }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 500, fontFamily: 'var(--font-mono)' }}>{o.id}</div>
+                  <div style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{o.vendor} · {o.items} items</div>
+                </div>
+                <span className={`badge ${o.status === 'Delivered' ? 'badge-success' : o.status === 'In transit' ? 'badge-info' : o.status === 'Cancelled' ? 'badge-danger' : 'badge-warn'}`}>{o.status}</span>
+                <div className="mono" style={{ fontSize: 13, fontWeight: 500, minWidth: 80, textAlign: 'right' }}>${o.amount.toLocaleString()}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SalesChart({ weeks }) {
+  const w = 600, h = 200;
+  const pad = { l: 36, r: 12, t: 12, b: 28 };
+  const max = Math.max(...weeks.map(d => d.sales)) * 1.1;
+  const x = i => pad.l + (i / (weeks.length - 1)) * (w - pad.l - pad.r);
+  const y = v => h - pad.b - (v / max) * (h - pad.t - pad.b);
+  const linePts = weeks.map((d, i) => `${x(i)},${y(d.sales)}`).join(' ');
+  const areaPts = `${pad.l},${h - pad.b} ${linePts} ${x(weeks.length - 1)},${h - pad.b}`;
+  const unitsPts = weeks.map((d, i) => `${x(i)},${y(d.units * 15)}`).join(' ');
+  const grid = [0, 0.25, 0.5, 0.75, 1];
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} style={{ width: '100%', height: 'auto' }}>
+      <defs>
+        <linearGradient id="salesg" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor="#f97316" stopOpacity="0.22" />
+          <stop offset="1" stopColor="#f97316" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {grid.map((g, i) => (
+        <g key={i}>
+          <line x1={pad.l} x2={w - pad.r} y1={pad.t + g * (h - pad.t - pad.b)} y2={pad.t + g * (h - pad.t - pad.b)} stroke="var(--border)" strokeDasharray="2 4" />
+          <text x={pad.l - 8} y={pad.t + g * (h - pad.t - pad.b) + 4} textAnchor="end" fontSize="9" fill="var(--text-dim)" fontFamily="var(--font-mono)">${Math.round((max * (1 - g)) / 1000)}k</text>
+        </g>
+      ))}
+      <polygon points={areaPts} fill="url(#salesg)" />
+      <polyline points={linePts} fill="none" stroke="#f97316" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      <polyline points={unitsPts} fill="none" stroke="#3b82f6" strokeWidth="1.5" strokeDasharray="4 3" strokeLinecap="round" />
+      {weeks.map((d, i) => (
+        <g key={i}>
+          <circle cx={x(i)} cy={y(d.sales)} r="3" fill="#f97316" stroke="var(--surface)" strokeWidth="1.5" />
+          <text x={x(i)} y={h - 10} textAnchor="middle" fontSize="10" fill="var(--text-dim)" fontFamily="var(--font-mono)">{d.w}</text>
+        </g>
+      ))}
+      <g transform={`translate(${w - pad.r - 130}, ${pad.t + 4})`}>
+        <rect width="130" height="36" fill="var(--surface)" stroke="var(--border)" rx="6" />
+        <circle cx="10" cy="13" r="3" fill="#f97316" />
+        <text x="20" y="17" fontSize="10" fill="var(--text-muted)">Revenue</text>
+        <line x1="6" x2="14" y1="27" y2="27" stroke="#3b82f6" strokeDasharray="2 2" strokeWidth="1.5" />
+        <text x="20" y="30" fontSize="10" fill="var(--text-muted)">Units</text>
+      </g>
+    </svg>
+  );
+}
+
+window.DashboardScreen = DashboardScreen;
+window.Sparkline = Sparkline;

--- a/medic_plus/public/daystar-health/parent-data.jsx
+++ b/medic_plus/public/daystar-health/parent-data.jsx
@@ -1,0 +1,35 @@
+// Daystar Merchandising — mock data
+const PRODUCTS = [
+  { id: 'DSM-1042', name: 'Heritage Tomato Sauce', category: 'Pantry', subcat: 'Sauces', size: '12 oz', price: 4.49, cost: 1.92, stock: 1842, reserved: 124, sold30d: 4210, status: 'In stock', supplier: 'Verde Foods Co.', rating: 4.7, margin: 57.2, trend: [62, 68, 64, 71, 78, 82, 89, 84, 91, 95, 88, 96] },
+  { id: 'DSM-2087', name: 'Sea Salt Sourdough', category: 'Bakery', subcat: 'Bread', size: '680 g', price: 6.99, cost: 2.85, stock: 184, reserved: 18, sold30d: 2890, status: 'Low stock', supplier: 'Stoneground Bakery', rating: 4.9, margin: 59.2, trend: [40, 45, 52, 58, 61, 66, 70, 74, 71, 75, 78, 82] },
+  { id: 'DSM-3019', name: 'Cold Brew Concentrate', category: 'Beverages', subcat: 'Coffee', size: '32 fl oz', price: 12.99, cost: 4.20, stock: 0, reserved: 0, sold30d: 1240, status: 'Out of stock', supplier: 'North Roasters', rating: 4.6, margin: 67.7, trend: [88, 84, 80, 72, 65, 54, 42, 30, 22, 14, 8, 0] },
+  { id: 'DSM-4451', name: 'Organic Whole Milk', category: 'Dairy', subcat: 'Milk', size: '64 fl oz', price: 5.49, cost: 2.10, stock: 2410, reserved: 220, sold30d: 8920, status: 'In stock', supplier: 'Pasture Bend Farms', rating: 4.8, margin: 61.7, trend: [70, 72, 75, 73, 78, 80, 84, 87, 89, 88, 91, 93] },
+  { id: 'DSM-5523', name: 'Spiced Apple Cider', category: 'Beverages', subcat: 'Juice', size: '64 fl oz', price: 7.99, cost: 2.95, stock: 612, reserved: 42, sold30d: 1180, status: 'In stock', supplier: 'Orchard Lane', rating: 4.5, margin: 63.1, trend: [45, 48, 52, 55, 58, 62, 65, 68, 71, 70, 72, 74] },
+  { id: 'DSM-6112', name: 'Aged Cheddar Wedge', category: 'Dairy', subcat: 'Cheese', size: '8 oz', price: 9.49, cost: 3.80, stock: 96, reserved: 14, sold30d: 1890, status: 'Low stock', supplier: 'Hollow Creek Creamery', rating: 4.9, margin: 60.0, trend: [60, 62, 65, 64, 68, 70, 72, 71, 74, 76, 78, 80] },
+  { id: 'DSM-7034', name: 'Honey-Roasted Granola', category: 'Pantry', subcat: 'Cereal', size: '14 oz', price: 8.99, cost: 3.10, stock: 1340, reserved: 88, sold30d: 2180, status: 'In stock', supplier: 'Meadow Pantry', rating: 4.7, margin: 65.5, trend: [50, 53, 56, 60, 63, 65, 68, 70, 73, 75, 77, 79] },
+  { id: 'DSM-8201', name: 'Wild Caught Smoked Salmon', category: 'Seafood', subcat: 'Smoked', size: '6 oz', price: 16.99, cost: 7.50, stock: 218, reserved: 36, sold30d: 980, status: 'In stock', supplier: 'Coastline Seafood', rating: 4.8, margin: 55.9, trend: [42, 45, 48, 50, 52, 55, 58, 60, 62, 64, 65, 67] },
+  { id: 'DSM-9117', name: 'Single-Origin Dark Chocolate', category: 'Snacks', subcat: 'Confectionery', size: '3.5 oz', price: 5.99, cost: 1.85, stock: 1820, reserved: 145, sold30d: 3120, status: 'In stock', supplier: 'Cocoa & Co.', rating: 4.9, margin: 69.1, trend: [65, 68, 70, 73, 76, 78, 81, 83, 86, 88, 90, 92] },
+  { id: 'DSM-1188', name: 'Sparkling Mineral Water', category: 'Beverages', subcat: 'Water', size: '750 ml', price: 3.49, cost: 0.95, stock: 4280, reserved: 312, sold30d: 6420, status: 'In stock', supplier: 'Glacier Springs', rating: 4.6, margin: 72.8, trend: [80, 82, 85, 87, 90, 88, 92, 94, 91, 93, 95, 97] },
+  { id: 'DSM-1290', name: 'Cracked Pepper Crackers', category: 'Snacks', subcat: 'Crackers', size: '8 oz', price: 4.99, cost: 1.40, stock: 28, reserved: 4, sold30d: 1240, status: 'Low stock', supplier: 'Mill House', rating: 4.5, margin: 71.9, trend: [55, 56, 58, 60, 62, 64, 65, 67, 68, 69, 70, 72] },
+  { id: 'DSM-1342', name: 'Free-Range Brown Eggs', category: 'Dairy', subcat: 'Eggs', size: '12 ct', price: 6.49, cost: 2.40, stock: 1120, reserved: 96, sold30d: 5240, status: 'In stock', supplier: 'Pasture Bend Farms', rating: 4.8, margin: 63.0, trend: [72, 74, 76, 78, 80, 82, 84, 86, 88, 89, 90, 92] },
+];
+
+const ORDERS = [
+  { id: '#PO-67142', date: 'Apr 28', vendor: 'Verde Foods Co.', items: 12, amount: 4280.00, status: 'Delivered', method: 'Net 30' },
+  { id: '#PO-67098', date: 'Apr 27', vendor: 'Stoneground Bakery', items: 4, amount: 892.50, status: 'In transit', method: 'Net 15' },
+  { id: '#PO-67051', date: 'Apr 26', vendor: 'North Roasters', items: 8, amount: 1840.00, status: 'Pending', method: 'Net 30' },
+  { id: '#PO-67012', date: 'Apr 25', vendor: 'Pasture Bend Farms', items: 18, amount: 6210.75, status: 'Delivered', method: 'Net 30' },
+  { id: '#PO-66988', date: 'Apr 24', vendor: 'Orchard Lane', items: 6, amount: 720.40, status: 'Delivered', method: 'Net 15' },
+  { id: '#PO-66954', date: 'Apr 23', vendor: 'Hollow Creek Creamery', items: 9, amount: 1480.00, status: 'Cancelled', method: 'Net 30' },
+  { id: '#PO-66921', date: 'Apr 22', vendor: 'Meadow Pantry', items: 5, amount: 980.20, status: 'Delivered', method: 'Net 30' },
+  { id: '#PO-66887', date: 'Apr 21', vendor: 'Coastline Seafood', items: 3, amount: 1620.00, status: 'In transit', method: 'Wire' },
+];
+
+const STORES = [
+  { id: 'DT-01', name: 'Daystar Downtown', city: 'Brooklyn, NY', staff: 14, sales: 184200 },
+  { id: 'WS-02', name: 'Daystar Westside', city: 'Portland, OR', staff: 11, sales: 142800 },
+  { id: 'NB-03', name: 'Daystar North Bay', city: 'Oakland, CA', staff: 9, sales: 98400 },
+  { id: 'CV-04', name: 'Daystar Central Valley', city: 'Austin, TX', staff: 12, sales: 156200 },
+];
+
+window.DSM_DATA = { PRODUCTS, ORDERS, STORES };

--- a/medic_plus/public/daystar-health/parent-icons.jsx
+++ b/medic_plus/public/daystar-health/parent-icons.jsx
@@ -1,0 +1,59 @@
+// Daystar — minimal icon set (24px stroke=1.75)
+const Icon = ({ d, children, size = 18, fill = 'none', stroke = 'currentColor', strokeWidth = 1.75, ...props }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke={stroke} strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round" {...props}>
+    {d ? <path d={d} /> : children}
+  </svg>
+);
+
+const Icons = {
+  Logo: ({ size = 20 }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <rect x="2" y="2" width="20" height="20" rx="6" fill="url(#dsg)" />
+      <path d="M7 12 L11 16 L17 8" stroke="white" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+      <defs>
+        <linearGradient id="dsg" x1="0" y1="0" x2="24" y2="24">
+          <stop offset="0" stopColor="#fb923c" />
+          <stop offset="1" stopColor="#f97316" />
+        </linearGradient>
+      </defs>
+    </svg>
+  ),
+  Home: (p) => <Icon {...p}><path d="M3 12 L12 4 L21 12" /><path d="M5 10 V20 H19 V10" /></Icon>,
+  Box: (p) => <Icon {...p}><path d="M21 8 L12 3 L3 8 L12 13 Z" /><path d="M3 8 V16 L12 21 L21 16 V8" /><path d="M12 13 V21" /></Icon>,
+  Cart: (p) => <Icon {...p}><circle cx="9" cy="20" r="1.5" /><circle cx="17" cy="20" r="1.5" /><path d="M3 4 H6 L8 14 H18 L20 7 H7" /></Icon>,
+  Tag: (p) => <Icon {...p}><path d="M3 12 V3 H12 L21 12 L12 21 Z" /><circle cx="7.5" cy="7.5" r="1.2" fill="currentColor" stroke="none"/></Icon>,
+  Users: (p) => <Icon {...p}><circle cx="9" cy="8" r="3.5" /><path d="M3 20 C3 16 6 14 9 14 C12 14 15 16 15 20" /><circle cx="17" cy="9" r="2.5" /><path d="M16 14 C19 14 21 16 21 20" /></Icon>,
+  Settings: (p) => <Icon {...p}><circle cx="12" cy="12" r="3" /><path d="M12 2 V4 M12 20 V22 M4.93 4.93 L6.34 6.34 M17.66 17.66 L19.07 19.07 M2 12 H4 M20 12 H22 M4.93 19.07 L6.34 17.66 M17.66 6.34 L19.07 4.93" /></Icon>,
+  Search: (p) => <Icon {...p} size={p.size || 16}><circle cx="11" cy="11" r="7" /><path d="M16 16 L21 21" /></Icon>,
+  Bell: (p) => <Icon {...p}><path d="M6 8 C6 5 8 3 12 3 C16 3 18 5 18 8 V13 L20 16 H4 L6 13 Z" /><path d="M10 19 C10.5 20 11.2 20.5 12 20.5 C12.8 20.5 13.5 20 14 19" /></Icon>,
+  Plus: (p) => <Icon {...p}><path d="M12 5 V19 M5 12 H19" /></Icon>,
+  Filter: (p) => <Icon {...p}><path d="M3 5 H21 L14 13 V20 L10 18 V13 Z" /></Icon>,
+  Download: (p) => <Icon {...p}><path d="M12 4 V15 M7 11 L12 16 L17 11" /><path d="M4 19 H20" /></Icon>,
+  ChevronDown: (p) => <Icon {...p}><path d="M6 9 L12 15 L18 9" /></Icon>,
+  ChevronRight: (p) => <Icon {...p}><path d="M9 6 L15 12 L9 18" /></Icon>,
+  ChevronLeft: (p) => <Icon {...p}><path d="M15 6 L9 12 L15 18" /></Icon>,
+  Up: (p) => <Icon {...p} size={p.size || 12}><path d="M5 15 L12 8 L19 15" /></Icon>,
+  Down: (p) => <Icon {...p} size={p.size || 12}><path d="M5 9 L12 16 L19 9" /></Icon>,
+  Check: (p) => <Icon {...p}><path d="M5 12 L10 17 L19 7" /></Icon>,
+  X: (p) => <Icon {...p}><path d="M6 6 L18 18 M18 6 L6 18" /></Icon>,
+  Mail: (p) => <Icon {...p}><rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3 7 L12 13 L21 7" /></Icon>,
+  Lock: (p) => <Icon {...p}><rect x="4" y="11" width="16" height="10" rx="2" /><path d="M8 11 V7 C8 4.5 9.8 3 12 3 C14.2 3 16 4.5 16 7 V11" /></Icon>,
+  Eye: (p) => <Icon {...p}><path d="M2 12 C4 6 8 4 12 4 C16 4 20 6 22 12 C20 18 16 20 12 20 C8 20 4 18 2 12 Z" /><circle cx="12" cy="12" r="3" /></Icon>,
+  EyeOff: (p) => <Icon {...p}><path d="M3 3 L21 21" /><path d="M9.5 9.5 C9 10.2 8.7 11.1 8.7 12 C8.7 13.8 10.2 15.3 12 15.3 C12.9 15.3 13.8 15 14.5 14.5" /><path d="M6 6.5 C4 8 3 10 2 12 C4 18 8 20 12 20 C13.6 20 15.1 19.7 16.5 19" /><path d="M11 4.1 C11.3 4 11.6 4 12 4 C16 4 20 6 22 12 C21.4 13.5 20.7 14.7 19.9 15.7" /></Icon>,
+  ArrowLeft: (p) => <Icon {...p}><path d="M19 12 H5 M12 5 L5 12 L12 19" /></Icon>,
+  ArrowRight: (p) => <Icon {...p}><path d="M5 12 H19 M12 5 L19 12 L12 19" /></Icon>,
+  Trend: (p) => <Icon {...p}><path d="M3 17 L9 11 L13 15 L21 7" /><path d="M14 7 H21 V14" /></Icon>,
+  Star: (p) => <Icon {...p}><path d="M12 3 L14.5 9 L21 9.5 L16 14 L17.5 20.5 L12 17 L6.5 20.5 L8 14 L3 9.5 L9.5 9 Z" /></Icon>,
+  Edit: (p) => <Icon {...p}><path d="M4 20 H8 L19 9 L15 5 L4 16 Z" /><path d="M14 6 L18 10" /></Icon>,
+  Copy: (p) => <Icon {...p}><rect x="8" y="8" width="12" height="12" rx="2" /><path d="M16 8 V6 C16 4.9 15.1 4 14 4 H6 C4.9 4 4 4.9 4 6 V14 C4 15.1 4.9 16 6 16 H8" /></Icon>,
+  More: (p) => <Icon {...p}><circle cx="6" cy="12" r="1.2" fill="currentColor" /><circle cx="12" cy="12" r="1.2" fill="currentColor" /><circle cx="18" cy="12" r="1.2" fill="currentColor" /></Icon>,
+  Calendar: (p) => <Icon {...p}><rect x="3" y="5" width="18" height="16" rx="2" /><path d="M3 10 H21 M8 3 V7 M16 3 V7" /></Icon>,
+  Pin: (p) => <Icon {...p}><path d="M12 2 V12 L18 18 V21 H6 V18 L12 12" /><path d="M9 8 H15" /></Icon>,
+  Truck: (p) => <Icon {...p}><rect x="2" y="7" width="13" height="10" rx="1" /><path d="M15 10 H19 L22 14 V17 H15" /><circle cx="6" cy="18" r="1.8" /><circle cx="18" cy="18" r="1.8" /></Icon>,
+  AlertTriangle: (p) => <Icon {...p}><path d="M12 4 L22 20 H2 Z" /><path d="M12 10 V14 M12 17 V17.1" /></Icon>,
+  Logout: (p) => <Icon {...p}><path d="M16 17 L21 12 L16 7" /><path d="M21 12 H9" /><path d="M9 4 H5 C3.9 4 3 4.9 3 6 V18 C3 19.1 3.9 20 5 20 H9" /></Icon>,
+  Camera: (p) => <Icon {...p}><rect x="3" y="7" width="18" height="13" rx="2" /><circle cx="12" cy="13" r="3.5" /><path d="M8 7 L9.5 4 H14.5 L16 7" /></Icon>,
+  Building: (p) => <Icon {...p}><rect x="4" y="3" width="16" height="18" rx="1" /><path d="M9 7 H10 M14 7 H15 M9 11 H10 M14 11 H15 M9 15 H10 M14 15 H15 M10 21 V18 H14 V21" /></Icon>,
+};
+
+window.Icons = Icons;

--- a/medic_plus/public/daystar-health/styles.css
+++ b/medic_plus/public/daystar-health/styles.css
@@ -1,0 +1,600 @@
+/* Daystar Merchandising — design tokens */
+:root {
+  --font-sans: 'Geist', -apple-system, system-ui, sans-serif;
+  --font-mono: 'Geist Mono', ui-monospace, monospace;
+
+  /* light */
+  --bg: oklch(0.99 0.003 80);
+  --bg-subtle: oklch(0.975 0.004 80);
+  --surface: #ffffff;
+  --surface-2: oklch(0.98 0.004 80);
+  --border: oklch(0.92 0.005 80);
+  --border-strong: oklch(0.86 0.006 80);
+  --text: oklch(0.18 0.01 60);
+  --text-muted: oklch(0.50 0.008 60);
+  --text-dim: oklch(0.65 0.006 60);
+
+  --accent: #f97316;
+  --accent-hover: #ea580c;
+  --accent-soft: oklch(0.96 0.04 60);
+  --accent-text: #c2410c;
+
+  --success: #10b981;
+  --success-soft: oklch(0.95 0.05 160);
+  --warn: #f59e0b;
+  --warn-soft: oklch(0.96 0.06 90);
+  --danger: #ef4444;
+  --danger-soft: oklch(0.96 0.04 25);
+  --info: #3b82f6;
+  --info-soft: oklch(0.96 0.03 240);
+
+  --shadow-xs: 0 1px 2px rgba(15, 15, 15, 0.04);
+  --shadow-sm: 0 1px 3px rgba(15, 15, 15, 0.05), 0 1px 2px rgba(15, 15, 15, 0.04);
+  --shadow-md: 0 4px 12px -2px rgba(15, 15, 15, 0.06), 0 2px 4px rgba(15, 15, 15, 0.04);
+  --shadow-lg: 0 12px 32px -8px rgba(15, 15, 15, 0.10), 0 4px 8px rgba(15, 15, 15, 0.04);
+
+  --radius-sm: 6px;
+  --radius: 10px;
+  --radius-lg: 14px;
+
+  /* density (comfortable default) */
+  --row-h: 48px;
+  --pad-card: 20px;
+  --pad-cell: 14px 16px;
+  --gap: 16px;
+  --text-size: 14px;
+}
+
+[data-density="compact"] {
+  --row-h: 36px;
+  --pad-card: 14px;
+  --pad-cell: 8px 12px;
+  --gap: 10px;
+  --text-size: 13px;
+}
+
+[data-theme="dark"] {
+  --bg: oklch(0.16 0.005 60);
+  --bg-subtle: oklch(0.18 0.005 60);
+  --surface: oklch(0.20 0.006 60);
+  --surface-2: oklch(0.22 0.006 60);
+  --border: oklch(0.27 0.008 60);
+  --border-strong: oklch(0.34 0.008 60);
+  --text: oklch(0.96 0.005 80);
+  --text-muted: oklch(0.68 0.008 60);
+  --text-dim: oklch(0.50 0.008 60);
+
+  --accent-soft: oklch(0.30 0.06 60);
+  --accent-text: #fb923c;
+
+  --success-soft: oklch(0.28 0.06 160);
+  --warn-soft: oklch(0.30 0.07 90);
+  --danger-soft: oklch(0.30 0.06 25);
+  --info-soft: oklch(0.28 0.05 240);
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.35);
+  --shadow-md: 0 4px 12px -2px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 12px 32px -8px rgba(0, 0, 0, 0.5);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: var(--text-size);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: 'cv11', 'ss01';
+  letter-spacing: -0.005em;
+}
+
+#root { min-height: 100vh; }
+
+button { font-family: inherit; cursor: pointer; }
+input, select, textarea { font-family: inherit; }
+
+::selection { background: var(--accent); color: white; }
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 14px;
+  height: 36px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+  letter-spacing: -0.005em;
+}
+.btn-primary {
+  background: linear-gradient(180deg, #fb923c 0%, var(--accent) 100%);
+  color: white;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.2) inset, var(--shadow-sm);
+}
+.btn-primary:hover { background: linear-gradient(180deg, var(--accent) 0%, var(--accent-hover) 100%); }
+.btn-secondary {
+  background: var(--surface);
+  color: var(--text);
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-xs);
+}
+.btn-secondary:hover { background: var(--surface-2); }
+.btn-ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: transparent;
+}
+.btn-ghost:hover { background: var(--bg-subtle); color: var(--text); }
+.btn-sm { height: 30px; padding: 0 10px; font-size: 12px; }
+.btn-lg { height: 42px; padding: 0 18px; font-size: 14px; }
+.btn-block { width: 100%; }
+
+/* Inputs */
+.input, .select {
+  width: 100%;
+  height: 38px;
+  padding: 0 12px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.input:focus, .select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.input::placeholder { color: var(--text-dim); }
+
+.label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+
+.field { margin-bottom: 14px; }
+.help { font-size: 12px; color: var(--text-muted); margin-top: 6px; }
+
+/* Card */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-xs);
+}
+.card-pad { padding: var(--pad-card); }
+.card-header {
+  padding: 16px var(--pad-card);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.card-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+/* Badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+.badge-success { background: var(--success-soft); color: #047857; }
+[data-theme="dark"] .badge-success { color: #34d399; }
+.badge-warn { background: var(--warn-soft); color: #b45309; }
+[data-theme="dark"] .badge-warn { color: #fbbf24; }
+.badge-danger { background: var(--danger-soft); color: #b91c1c; }
+[data-theme="dark"] .badge-danger { color: #f87171; }
+.badge-info { background: var(--info-soft); color: #1d4ed8; }
+[data-theme="dark"] .badge-info { color: #60a5fa; }
+.badge-neutral { background: var(--bg-subtle); color: var(--text-muted); border: 1px solid var(--border); }
+
+/* Mono numbers */
+.mono { font-family: var(--font-mono); font-feature-settings: 'tnum'; }
+
+/* Table */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.table thead th {
+  text-align: left;
+  padding: var(--pad-cell);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: var(--bg-subtle);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.table tbody td {
+  padding: var(--pad-cell);
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  vertical-align: middle;
+}
+.table tbody tr { transition: background 0.1s; }
+.table tbody tr:hover { background: var(--bg-subtle); cursor: pointer; }
+.table tbody tr:last-child td { border-bottom: none; }
+
+/* Sidebar */
+.sidebar {
+  width: 240px;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+}
+.sidebar-brand {
+  padding: 18px 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--border);
+}
+.sidebar-nav {
+  padding: 12px 10px;
+  flex: 1;
+  overflow-y: auto;
+}
+.sidebar-section {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-dim);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 14px 12px 8px;
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  color: var(--text-muted);
+  font-size: 13.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.12s;
+  border: none;
+  background: transparent;
+  width: 100%;
+  text-align: left;
+}
+.nav-item:hover { background: var(--bg-subtle); color: var(--text); }
+.nav-item.active {
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+.nav-item.active svg { color: var(--accent); }
+
+/* Topbar */
+.topbar {
+  height: 60px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  gap: 16px;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  backdrop-filter: blur(8px);
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.page {
+  padding: 28px;
+  max-width: 1400px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* Avatar */
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #fb923c, #f97316);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
+.avatar-lg { width: 64px; height: 64px; font-size: 22px; }
+.avatar-sm { width: 24px; height: 24px; font-size: 10px; }
+
+/* Image placeholder */
+.placeholder-img {
+  background:
+    repeating-linear-gradient(
+      45deg,
+      var(--bg-subtle) 0px,
+      var(--bg-subtle) 8px,
+      var(--surface-2) 8px,
+      var(--surface-2) 16px
+    );
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: center;
+  padding: 8px;
+}
+
+/* Search */
+.search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.search input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px 0 36px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+}
+.search input:focus { border-color: var(--accent); background: var(--surface); }
+.search svg {
+  position: absolute;
+  left: 12px;
+  color: var(--text-dim);
+  pointer-events: none;
+}
+.search kbd {
+  position: absolute;
+  right: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: var(--text-muted);
+}
+
+/* Auth pages */
+.auth-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background:
+    radial-gradient(ellipse at top right, oklch(0.96 0.04 60) 0%, transparent 60%),
+    radial-gradient(ellipse at bottom left, oklch(0.97 0.02 240) 0%, transparent 60%),
+    var(--bg);
+}
+[data-theme="dark"] .auth-shell {
+  background:
+    radial-gradient(ellipse at top right, oklch(0.25 0.06 60) 0%, transparent 60%),
+    radial-gradient(ellipse at bottom left, oklch(0.22 0.04 240) 0%, transparent 60%),
+    var(--bg);
+}
+.auth-card {
+  width: 100%;
+  max-width: 420px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow-lg);
+  padding: 36px;
+}
+
+/* KPI tile */
+.kpi-tile {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--pad-card);
+  position: relative;
+  overflow: hidden;
+}
+.kpi-tile::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, var(--surface-2) 0%, transparent 50%);
+  pointer-events: none;
+  opacity: 0.6;
+}
+.kpi-tile > * { position: relative; }
+.kpi-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.kpi-value {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 8px 0 4px;
+  font-family: var(--font-mono);
+  font-feature-settings: 'tnum';
+}
+.kpi-delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-mono);
+}
+.kpi-delta.up { color: #047857; }
+.kpi-delta.down { color: #b91c1c; }
+[data-theme="dark"] .kpi-delta.up { color: #34d399; }
+[data-theme="dark"] .kpi-delta.down { color: #f87171; }
+
+/* Progress bar */
+.bar {
+  height: 6px;
+  background: var(--bg-subtle);
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+.bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.4s ease;
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--border);
+}
+.tab {
+  padding: 10px 14px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-bottom: -1px;
+}
+.tab:hover { color: var(--text); }
+.tab.active { color: var(--accent-text); border-bottom-color: var(--accent); }
+
+/* Segment */
+.segment {
+  display: inline-flex;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 2px;
+  gap: 2px;
+}
+.segment button {
+  padding: 5px 10px;
+  border-radius: 6px;
+  background: transparent;
+  border: none;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 500;
+  font-family: var(--font-mono);
+}
+.segment button.active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: var(--shadow-xs);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 5px; border: 2px solid var(--bg); }
+::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+
+/* Animations */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.fade-in { animation: fadeIn 0.25s ease; }
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+/* Checkbox */
+.checkbox {
+  width: 16px;
+  height: 16px;
+  border: 1.5px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.12s;
+}
+.checkbox.checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.checkbox.checked svg { color: white; }
+
+/* Toast */
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: var(--bg);
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  box-shadow: var(--shadow-lg);
+  z-index: 1000;
+  animation: fadeIn 0.2s ease;
+}

--- a/medic_plus/public/daystar-health/tweaks-panel.jsx
+++ b/medic_plus/public/daystar-health/tweaks-panel.jsx
@@ -1,0 +1,425 @@
+
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;width:100%;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel"
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">{children}</div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+function TweakColor({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <input type="color" className="twk-swatch" value={value}
+             onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});

--- a/medic_plus/tests/ui/test_daystar_health.py
+++ b/medic_plus/tests/ui/test_daystar_health.py
@@ -1,0 +1,100 @@
+"""
+UI Tests: Daystar Health SPA — auth flow (Issue #4)
+====================================================
+
+Behaviors tested:
+  1. Anonymous visit to /daystar-health renders the SPA login screen.
+  2. Submitting bad credentials surfaces an in-page error.
+  3. Submitting valid credentials reloads to the post-login screen.
+  4. An already-logged-in user without a Practice Member row sees the
+     "Practice not linked" error card.
+  5. Sign-out on the no-practice card returns the user to the login screen.
+
+Administrator has no Practice Member row on this site, which makes them the
+perfect fixture for the no-practice path. Test 3 asserts the post-login render
+(either dashboard or no-practice card) — proving the login wire round-trips.
+"""
+
+import re
+import pytest
+from playwright.sync_api import Page, expect
+
+from conftest import BASE_URL, ADMIN_USER, ADMIN_PASS
+
+
+DAYSTAR_URL = f"{BASE_URL}/daystar-health"
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _logout(page: Page) -> None:
+    """Drop any existing Frappe session by hitting /api/method/logout."""
+    page.context.clear_cookies()
+
+
+def _fill_login(page: Page, email: str, pwd: str) -> None:
+    page.locator('[data-testid="login-email"]').fill(email)
+    page.locator('[data-testid="login-password"]').fill(pwd)
+    page.locator('[data-testid="login-submit"]').click()
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+
+class TestAnonymousFlow:
+    """An unauthenticated visitor lands on the login screen and can attempt sign in."""
+
+    def test_anonymous_visit_shows_login_screen(self, page: Page):
+        _logout(page)
+        page.goto(DAYSTAR_URL)
+        expect(page.locator('[data-testid="login-email"]')).to_be_visible()
+        expect(page.locator('[data-testid="login-submit"]')).to_be_visible()
+        # Heading copy is part of the public contract — exposes the login intent.
+        expect(page.get_by_role("heading", name=re.compile("Sign in", re.I))).to_be_visible()
+
+    def test_invalid_credentials_show_error_message(self, page: Page):
+        _logout(page)
+        page.goto(DAYSTAR_URL)
+        _fill_login(page, "definitely-not-a-user@example.test", "wrong-pw")
+        # Error banner appears in-page (the SPA does not navigate away on failure).
+        expect(page.locator('[data-testid="login-error"]')).to_be_visible(timeout=15_000)
+        # User stays on login screen — no redirect happened.
+        expect(page.locator('[data-testid="login-email"]')).to_be_visible()
+
+
+class TestPostLoginRouting:
+    """After a successful login the SPA reloads and routes based on the user's
+    Practice Member status. Administrator has no Practice Member row, so they
+    land on the no-practice card."""
+
+    def test_admin_login_lands_on_no_practice_card(self, page: Page):
+        _logout(page)
+        page.goto(DAYSTAR_URL)
+        _fill_login(page, ADMIN_USER, ADMIN_PASS)
+        # Page reloads after login. The reload re-evaluates session + has_practice
+        # in daystar_health.py, and the SPA renders the no-practice card.
+        expect(page.locator('[data-testid="no-practice-card"]')).to_be_visible(timeout=20_000)
+        expect(page.get_by_role("heading", name=re.compile("Practice not linked", re.I))).to_be_visible()
+
+    def test_already_logged_in_admin_skips_login_screen(self, logged_in_admin_page: Page):
+        # Pre-condition: logged_in_admin_page fixture has an authenticated admin session.
+        page = logged_in_admin_page
+        page.goto(DAYSTAR_URL)
+        # Login screen must NOT appear — first-render routing skips it.
+        expect(page.locator('[data-testid="login-email"]')).not_to_be_visible(timeout=10_000)
+        # No-practice card IS visible because admin has no Practice Member row.
+        expect(page.locator('[data-testid="no-practice-card"]')).to_be_visible(timeout=10_000)
+
+
+class TestNoPracticeSignOut:
+    """Sign-out on the no-practice card releases the session and shows the login screen."""
+
+    def test_signout_returns_to_login_screen(self, logged_in_admin_page: Page):
+        page = logged_in_admin_page
+        page.goto(DAYSTAR_URL)
+        expect(page.locator('[data-testid="no-practice-card"]')).to_be_visible(timeout=10_000)
+        page.locator('[data-testid="no-practice-signout"]').click()
+        # logout() in meridian-api navigates to /daystar-health, which re-renders
+        # as Guest → login screen.
+        expect(page.locator('[data-testid="login-email"]')).to_be_visible(timeout=15_000)
+        expect(page.locator('[data-testid="no-practice-card"]')).not_to_be_visible()

--- a/medic_plus/www/daystar-health.html
+++ b/medic_plus/www/daystar-health.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Daystar Health</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/assets/medic_plus/daystar-health/styles.css" />
+<link rel="stylesheet" href="/assets/medic_plus/daystar-health/meridian.css" />
+</head>
+<body data-theme="light" data-density="comfortable">
+<div id="root"></div>
+
+<script>
+window.__DAYSTAR_HEALTH__ = {
+  csrfToken: {{ csrf_token | tojson }},
+  sessionUser: {{ session_user | tojson }},
+  hasPractice: {{ has_practice | tojson }}
+};
+</script>
+<script src="/assets/medic_plus/daystar-health/meridian-api.js"></script>
+
+{% raw %}
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin="anonymous"></script>
+
+<!-- Reuse base components from Daystar (Sparkline, Icons, etc.) -->
+<script type="text/babel" src="/assets/medic_plus/daystar-health/parent-data.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/parent-icons.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/parent-dashboard.jsx"></script>
+
+<!-- Daystar Health-specific -->
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-data.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-icons.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-layout.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-auth.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-dashboard.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-patients.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-patient.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-profile.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/tweaks-panel.jsx"></script>
+
+<script type="text/babel">
+const { useState, useEffect } = React;
+
+const TWEAK_DEFAULTS = {
+  "theme": "light",
+  "density": "comfortable"
+};
+
+function initialRoute() {
+  const api = window.meridianApi || {};
+  if (!api.isAuthenticated) return 'login';
+  if (!api.hasPractice) return 'no-practice';
+  return 'dashboard';
+}
+
+function App() {
+  const [route, setRoute] = useState(initialRoute);
+  const [routeArg, setRouteArg] = useState(null);
+  const [tweaks, setTweak] = window.useTweaks(TWEAK_DEFAULTS);
+
+  useEffect(() => {
+    document.body.dataset.theme = tweaks.theme;
+    document.body.dataset.density = tweaks.density;
+  }, [tweaks.theme, tweaks.density]);
+
+  const go = (r, arg = null) => { setRoute(r); setRouteArg(arg); window.scrollTo(0, 0); };
+
+  if (route === 'login') return <><window.MLoginScreen go={go} /><Tweaks tweaks={tweaks} setTweak={setTweak} /></>;
+  if (route === 'recover') return <><window.MRecoverScreen go={go} /><Tweaks tweaks={tweaks} setTweak={setTweak} /></>;
+  if (route === 'no-practice') return <><window.MNoPracticeScreen /><Tweaks tweaks={tweaks} setTweak={setTweak} /></>;
+
+  const titles = {
+    dashboard: 'Today', patients: 'Patients', appointments: 'Appointments',
+    records: 'Medical Records', labs: 'Labs & Imaging', medications: 'Prescriptions',
+    billing: 'Billing & Claims', practice: 'Practice', profile: 'Account'
+  };
+  let crumbs = [{ label: 'Daystar Health', go: () => go('dashboard') }];
+  if (route === 'patient') {
+    const p = window.MH_DATA.PATIENTS.find(x => x.id === routeArg);
+    crumbs.push({ label: 'Patients', go: () => go('patients') });
+    crumbs.push({ label: p?.name || 'Patient' });
+  } else if (titles[route]) {
+    crumbs.push({ label: titles[route] });
+  }
+
+  return (
+    <div className="app-shell">
+      <window.MSidebar route={route} go={go} />
+      <div className="main">
+        <window.MTopbar go={go} crumbs={crumbs} />
+        {route === 'dashboard' && <window.MDashboardScreen go={go} />}
+        {route === 'patients' && <window.MPatientsScreen go={go} />}
+        {route === 'patient' && <window.MPatientScreen patientId={routeArg} go={go} />}
+        {route === 'profile' && <window.MProfileScreen go={go} />}
+        {!['dashboard', 'patients', 'patient', 'profile'].includes(route) && (
+          <Placeholder name={titles[route] || route} />
+        )}
+      </div>
+      <Tweaks tweaks={tweaks} setTweak={setTweak} />
+    </div>
+  );
+}
+
+function Placeholder({ name }) {
+  return (
+    <div className="page fade-in">
+      <h1 style={{ fontSize: 22, fontWeight: 600, letterSpacing: '-0.02em' }}>{name}</h1>
+      <div className="card card-pad" style={{ marginTop: 16, textAlign: 'center', padding: 60 }}>
+        <div style={{ fontSize: 14, color: 'var(--text-muted)' }}>This section is part of the same product but isn't part of the 6-screen scope.</div>
+      </div>
+    </div>
+  );
+}
+
+function Tweaks({ tweaks, setTweak }) {
+  const TweaksPanel = window.TweaksPanel;
+  const TweakSection = window.TweakSection;
+  const TweakRadio = window.TweakRadio;
+  if (!TweaksPanel) return null;
+  return (
+    <TweaksPanel title="Tweaks">
+      <TweakSection label="Appearance" />
+      <TweakRadio label="Theme" value={tweaks.theme} options={['light','dark']} onChange={v => setTweak('theme', v)} />
+      <TweakRadio label="Density" value={tweaks.density} options={['comfortable','compact']} onChange={v => setTweak('density', v)} />
+    </TweaksPanel>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>{% endraw %}

--- a/medic_plus/www/daystar_health.py
+++ b/medic_plus/www/daystar_health.py
@@ -1,0 +1,25 @@
+import frappe
+
+from medic_plus.api.practice_resolver import get_active_practice
+
+no_cache = 1
+
+
+def get_context(context):
+	"""Bootstrap the Daystar Health SPA with session + CSRF state.
+
+	The SPA decides its first-render route from `session_user` and `has_practice`
+	and uses `csrf_token` for non-GET API calls. Resolving here avoids an
+	additional client-side round trip to determine login state on first paint.
+	"""
+	context.no_cache = 1
+	context.session_user = frappe.session.user
+
+	try:
+		get_active_practice()
+		context.has_practice = True
+	except frappe.PermissionError:
+		context.has_practice = False
+
+	context.csrf_token = frappe.sessions.get_csrf_token()
+	return context

--- a/techspec.md
+++ b/techspec.md
@@ -4,6 +4,39 @@ Living technical specification. Every feature, bugfix, refactor, and design deci
 
 ---
 
+## 2026-04-29 — Phase 1F (Issue #4): Daystar Health SPA — auth flow wired to Frappe
+
+### Scope
+Slice 1 of 5 for the `/daystar-health` Single-Page Application: replace the mock authentication with real Frappe auth, and lay the foundation that subsequent screens (dashboard, patients list, patient detail, profile) reuse.
+
+### Deep module: `practice_resolver`
+- `get_active_practice(user) -> str` resolves the user's active Practice via `Practice Member`, the single source of truth for "which Practice does this user belong to" across all Daystar Health endpoints.
+- Raises `frappe.PermissionError` for Guest and for any user without a Practice Member row. `Healthcare Administrator` role is *not* specially privileged here — admins still need a Practice Member to use this UI (they retain Frappe Desk access for admin work).
+
+### SPA bootstrap
+- `www/daystar_health.py` exposes `csrf_token`, `session_user`, and `has_practice` to the template via `get_context()`. Resolving `has_practice` server-side eliminates a first-render round trip and lets the SPA choose its initial route synchronously.
+- `meridian-api.js` is the new centralised SPA API client — wraps `fetch` with CSRF + JSON conventions, surfaces `call`, `resource`, `login`, `recoverPassword`, `logout`, `showError`. Every later slice consumes this helper rather than rolling its own.
+
+### Auth screens (`meridian-auth.jsx`)
+- `MLoginScreen` posts to `/api/method/login` with username/email + password. In-page error banner on bad credentials. Username (e.g. `Administrator`) and email both accepted (`type="text"` rather than `type="email"`).
+- `MRecoverScreen` posts to `frappe.core.doctype.user.user.reset_password`.
+- New `MNoPracticeScreen` renders for authenticated users without a Practice Member row. Sign-out posts to `/api/method/logout` with the CSRF token.
+
+### First-render routing
+The SPA's `initialRoute()` reads the bootstrap and chooses `login` / `no-practice` / `dashboard` at mount time. Already-authenticated users no longer see the login screen flicker.
+
+### Tests
+- Python: 3 unit tests for `practice_resolver` (member returns Practice, no-membership raises, Guest raises). Mocks `frappe.db` to keep tests pure; LocalProxy bound in `setUpModule` to avoid Python 3.14 + ContextVar issues.
+- Playwright: 5 tests covering anonymous → login screen, invalid credentials surface in-page error, admin login lands on no-practice card, already-logged-in admin skips login, sign-out returns to login.
+
+### Bug surfaced
+Frappe's website page renderer (`template_page.set_pymodule`) maps hyphenated `.html` templates to underscored `.py` companion modules. The pre-existing `daystar-health.py` was therefore dead code — Frappe was looking for `daystar_health.py`. Renamed to fix the bootstrap injection.
+
+### Out of scope (later slices)
+- Dashboard, patients list, patient detail, profile — all still consume static `MH_DATA` mocks. Issues #5, #6, #7, #8.
+
+---
+
 ## 2026-04-08 — Phase 3: Platform Owner Workspace
 
 ### Requirement


### PR DESCRIPTION
Closes #4. Slice 1 of 5 wiring the `/daystar-health` SPA to real Frappe APIs.

## Summary

- **Deep module** `api/practice_resolver.get_active_practice(user)` — single source of truth for "which Practice does this user belong to" across all Daystar Health endpoints. Raises `frappe.PermissionError` for Guest and for users without a `Practice Member` row.
- **Page bootstrap** `www/daystar_health.py` exposes `csrf_token`, `session_user`, `has_practice` to the template, eliminating a first-render round trip.
- **API client** `meridian-api.js` centralises CSRF + JSON conventions for every later screen — `call`, `resource`, `login`, `recoverPassword`, `logout`, `showError`.
- **Auth screens** `meridian-auth.jsx` — real `/api/method/login`, `reset_password`, and a new `MNoPracticeScreen` for authenticated users without a Practice Member row.
- **First-render routing** in `daystar-health.html` reads the bootstrap and chooses login / no-practice / dashboard at mount.

## Bug fix

Frappe's website page renderer maps hyphenated `.html` templates to underscored `.py` companions. The pre-existing `daystar-health.py` was therefore dead code. Renamed to `daystar_health.py` to make the bootstrap injection actually work.

## Test plan

- [x] `env/bin/python -m pytest apps/medic_plus/medic_plus/api/test_daystar_health.py -v` — 3 passed
- [x] `env/bin/python -m pytest apps/medic_plus/medic_plus/tests/ui/test_daystar_health.py -v` — 5 passed
- [x] Manual: anonymous visit shows login; bad creds show error; admin sign-in lands on no-practice card; already-logged-in admin skips login; sign-out returns to login.

## Out of scope (later slices)

Dashboard, patients list, patient detail, profile screens — all still consume static `MH_DATA` mocks. Tracked in Issues #5, #6, #7, #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)