### PR TITLE
Wire Daystar Health dashboard to live Practice data (#5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ MIT
 
 ## Changelog
 
+### 2026-04-29 — Phase 1G (Issue #5): Daystar Health dashboard wired to live Practice data
+- Slice 2 of 5 wiring the `/daystar-health` SPA. Dashboard now hydrates from a real composite endpoint instead of `MH_DATA` mocks.
+- New deep module `api/dashboard_aggregator` — `build_dashboard(practice, user)` orchestrator + pure `_format_dashboard(...)` helper for testable shaping rules (greeting personalisation, week-volume always 7 days, recent-patients cap of 6, today-appointment status breakdown using the real Healthcare statuses).
+- New whitelisted endpoint `medic_plus.api.daystar_health.get_dashboard` — thin orchestrator. Surfaces `frappe.PermissionError` from `practice_resolver` unchanged so the SPA can render the no-practice card.
+- Dashboard screen rewrite in `meridian-dashboard.jsx`: skeletons during load, error toast + inline error card on failure, three KPI tiles (today's appointments / active patients / outstanding labs), today's schedule, week-volume chart, recent-patients table.
+- Per design decision: dropped "Pending refills" KPI, "Needs attention" panel, MRN/Risk/Status columns, Day/Week/Month toggle, "New appointment" button. "View full schedule" links to Frappe Desk Patient Appointment list scoped to today + Practice.
+- Outstanding labs KPI uses a JOIN through `Patient.custom_practice` since `Lab Test` has no `custom_practice` field — avoided schema migration.
+- Tests: 4 format-helper unit tests + 2 endpoint contract tests + 1 Playwright dashboard render test (uses a temporary Practice Member row for Administrator with role=Admin to bypass the Doctor→Practitioner validation).
+
 ### 2026-04-29 — Phase 1F (Issue #4): Daystar Health SPA — auth flow wired to Frappe
 - Slice 1 of 5 wiring the `/daystar-health` SPA to real Frappe APIs.
 - New `practice_resolver.get_active_practice(user)` deep module — returns the user's active Practice or raises `frappe.PermissionError` for Guest / no-membership users. Reusable across all later Daystar Health endpoints.

--- a/medic_plus/api/dashboard_aggregator.py
+++ b/medic_plus/api/dashboard_aggregator.py
@@ -1,0 +1,200 @@
+"""Compose the Daystar Health dashboard payload.
+
+The deep module orchestrates DB reads + payload shaping for the dashboard
+screen. Splits into:
+
+- ``build_dashboard(practice, user)`` — the public entry point that resolves
+  the user's first name, runs the queries scoped to the Practice, and
+  delegates to the format helper.
+- ``_format_dashboard(...)`` — pure transformation; takes already-fetched
+  values and returns the payload dict. Testable in isolation without a DB.
+"""
+
+from datetime import date, datetime, timedelta
+from urllib.parse import urlencode
+
+import frappe
+from frappe.utils import format_date, getdate, today
+
+# Statuses we treat as "outstanding" for the labs KPI. The Healthcare Lab Test
+# lifecycle moves Open → Started → Approved/Completed; the first two are work
+# the practitioner still owes the patient.
+_OUTSTANDING_LAB_STATUSES = ("Open", "Started")
+
+
+def build_dashboard(*, practice: str, user: str) -> dict:
+    """Compose the Daystar Health dashboard payload for a given Practice."""
+    user_doc = frappe.db.get_value(
+        "User", user, ["first_name", "last_name"], as_dict=True
+    ) or frappe._dict(first_name="", last_name="")
+
+    today_date = getdate(today())
+    today_iso = today_date.isoformat()
+
+    # Today's appointments — list shaped for the schedule card AND counted for KPI.
+    appt_rows = frappe.db.get_all(
+        "Patient Appointment",
+        filters={"custom_practice": practice, "appointment_date": today_iso},
+        fields=[
+            "name", "patient", "patient_name", "appointment_time",
+            "duration", "practitioner", "practitioner_name", "status",
+            "appointment_type",
+        ],
+        order_by="appointment_time asc",
+    )
+    today_appointments = [
+        {
+            "id": r.name,
+            "patient_id": r.patient,
+            "patient_name": r.patient_name or "",
+            "time": _format_time(r.appointment_time),
+            "duration": int(r.duration or 0),
+            "practitioner": r.practitioner_name or r.practitioner or "",
+            "reason": r.appointment_type or "",
+            "status": r.status or "",
+        }
+        for r in appt_rows
+    ]
+
+    # Active patient count for the Practice.
+    active_patient_count = frappe.db.count(
+        "Patient",
+        filters={"custom_practice": practice, "status": "Active"},
+    )
+
+    # Outstanding labs: Lab Test has no custom_practice field, so we scope via
+    # the patient's tenant link.
+    outstanding_lab_count = frappe.db.sql(
+        """
+        SELECT COUNT(*) FROM `tabLab Test` lt
+        INNER JOIN `tabPatient` p ON p.name = lt.patient
+        WHERE p.custom_practice = %(practice)s
+          AND lt.status IN %(statuses)s
+        """,
+        {"practice": practice, "statuses": _OUTSTANDING_LAB_STATUSES},
+    )[0][0]
+
+    # Week volume: encounters per day for the last 7 days, keyed by short
+    # weekday name so the format helper can fill missing days with 0.
+    week_start = today_date - timedelta(days=6)
+    encounter_rows = frappe.db.get_all(
+        "Patient Encounter",
+        filters={
+            "custom_practice": practice,
+            "encounter_date": [">=", week_start.isoformat()],
+        },
+        fields=["encounter_date"],
+        limit_page_length=0,
+    )
+    weekly_counts: dict = {}
+    for row in encounter_rows:
+        d = getdate(row.encounter_date)
+        key = d.strftime("%a")
+        weekly_counts[key] = weekly_counts.get(key, 0) + 1
+
+    # Recent patients: latest 6 with at least one encounter, ordered by most
+    # recent encounter date.
+    recent_rows = frappe.db.sql(
+        """
+        SELECT p.name AS id, p.patient_name AS name,
+               TIMESTAMPDIFF(YEAR, p.dob, CURDATE()) AS age,
+               p.sex,
+               MAX(e.encounter_date) AS last_seen
+        FROM `tabPatient` p
+        INNER JOIN `tabPatient Encounter` e ON e.patient = p.name
+        WHERE p.custom_practice = %(practice)s
+        GROUP BY p.name, p.patient_name, p.dob, p.sex
+        ORDER BY last_seen DESC
+        LIMIT 12
+        """,
+        {"practice": practice},
+        as_dict=True,
+    )
+    recent_patient_rows = [
+        {
+            "id": r.id,
+            "name": r.name or "",
+            "age": int(r.age) if r.age is not None else None,
+            "sex": (r.sex or "")[:1],
+            "last_seen": format_date(r.last_seen) if r.last_seen else "",
+        }
+        for r in recent_rows
+    ]
+
+    return _format_dashboard(
+        user_first_name=user_doc.first_name or "",
+        today_appointments=today_appointments,
+        active_patient_count=active_patient_count,
+        outstanding_lab_count=int(outstanding_lab_count),
+        weekly_encounter_counts=weekly_counts,
+        recent_patient_rows=recent_patient_rows,
+        view_full_schedule_url=_full_schedule_url(practice, today_iso),
+        today_label=_format_today_label(today_date),
+    )
+
+
+def _format_time(value) -> str:
+    """Return HH:MM for a timedelta / time / str input from Patient Appointment."""
+    if value is None:
+        return ""
+    if isinstance(value, timedelta):
+        total = int(value.total_seconds())
+        return f"{total // 3600:02d}:{(total % 3600) // 60:02d}"
+    if isinstance(value, str):
+        return value[:5]
+    return value.strftime("%H:%M")
+
+
+def _format_today_label(d: date) -> str:
+    return d.strftime("%A, %B %d")
+
+
+def _full_schedule_url(practice: str, iso_date: str) -> str:
+    qs = urlencode({"custom_practice": practice, "appointment_date": iso_date})
+    return f"/app/patient-appointment?{qs}"
+
+# Display order for the week-volume chart — Monday→Sunday matches the
+# clinic week the design renders.
+_WEEK_DAYS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+# Cap the dashboard's recent-patients table so the at-a-glance card never
+# stretches past the design height.
+_RECENT_PATIENTS_LIMIT = 6
+
+
+def _format_dashboard(
+    *,
+    user_first_name: str,
+    today_appointments: list,
+    active_patient_count: int,
+    outstanding_lab_count: int,
+    weekly_encounter_counts: dict,
+    recent_patient_rows: list,
+    view_full_schedule_url: str,
+    today_label: str,
+) -> dict:
+    greeting = f"Good morning, Dr. {user_first_name}" if user_first_name else "Good morning"
+    week_volume = [
+        {"day": d, "visits": int(weekly_encounter_counts.get(d, 0))}
+        for d in _WEEK_DAYS
+    ]
+    breakdown: dict = {}
+    for appt in today_appointments:
+        status = appt.get("status") or "Unknown"
+        breakdown[status] = breakdown.get(status, 0) + 1
+    return {
+        "greeting": greeting,
+        "today_label": today_label,
+        "kpis": {
+            "today_appointments": {
+                "value": len(today_appointments),
+                "breakdown": breakdown,
+            },
+            "active_patients": {"value": int(active_patient_count)},
+            "outstanding_labs": {"value": int(outstanding_lab_count)},
+        },
+        "today_schedule": list(today_appointments),
+        "week_volume": week_volume,
+        "recent_patients": list(recent_patient_rows)[:_RECENT_PATIENTS_LIMIT],
+        "view_full_schedule_url": view_full_schedule_url,
+    }

--- a/medic_plus/api/daystar_health.py
+++ b/medic_plus/api/daystar_health.py
@@ -1,0 +1,24 @@
+"""Whitelisted endpoints for the Daystar Health SPA at /daystar-health.
+
+Each endpoint is a thin orchestrator:
+  - resolve the active Practice via practice_resolver (raises PermissionError
+    when the caller has no Practice Member row);
+  - run the doctype-scoped queries;
+  - hand them to the appropriate aggregator for shaping;
+  - return a JSON-serialisable payload.
+
+Heavy logic lives in the deep modules (dashboard_aggregator,
+patient_summary, …) so it can be tested in isolation.
+"""
+
+import frappe
+
+from medic_plus.api.dashboard_aggregator import build_dashboard
+from medic_plus.api.practice_resolver import get_active_practice
+
+
+@frappe.whitelist()
+def get_dashboard() -> dict:
+    """Return the dashboard payload for the logged-in user's active Practice."""
+    practice = get_active_practice()
+    return build_dashboard(practice=practice, user=frappe.session.user)

--- a/medic_plus/api/test_daystar_health.py
+++ b/medic_plus/api/test_daystar_health.py
@@ -82,3 +82,175 @@ class TestPracticeResolver(unittest.TestCase):
             with self.assertRaises(frappe.PermissionError):
                 m.get_active_practice(user="Guest")
         gv.assert_not_called()
+
+
+class TestDashboardFormatHelper(unittest.TestCase):
+    """Behavior tests for dashboard_aggregator._format_dashboard.
+
+    This is the pure-data-shaping helper: it takes already-fetched rows and
+    counts and returns the dashboard payload. No DB, no session, no
+    frappe.utils. Testing it in isolation gives us fast, focused coverage of
+    the interesting transformation rules (capping, day-series shaping,
+    breakdown labelling, greeting personalisation).
+    """
+
+    def _import(self):
+        from medic_plus.api import dashboard_aggregator
+        return dashboard_aggregator
+
+    def _empty_inputs(self):
+        """Default zero-state input the helper accepts. Tests override only
+        the keys they care about, keeping each test focused on one rule."""
+        return {
+            "user_first_name": "",
+            "today_appointments": [],
+            "active_patient_count": 0,
+            "outstanding_lab_count": 0,
+            "weekly_encounter_counts": {},
+            "recent_patient_rows": [],
+            "view_full_schedule_url": "/app/patient-appointment",
+            "today_label": "Wednesday, April 29",
+        }
+
+    def test_greeting_uses_user_first_name(self):
+        """The greeting addresses the logged-in practitioner by first name so
+        the dashboard feels personal. When the first name is empty the greeting
+        falls back to a generic phrasing rather than an awkward 'Good morning, '."""
+        m = self._import()
+        inputs = self._empty_inputs()
+        inputs["user_first_name"] = "Sanjay"
+        payload = m._format_dashboard(**inputs)
+        self.assertIn("Sanjay", payload["greeting"])
+
+    def test_week_volume_returns_seven_days_even_with_sparse_input(self):
+        """The week-volume chart needs a stable 7-day x-axis. When some days
+        had zero encounters the helper must fill them with 0 rather than
+        skipping them — otherwise the chart shifts left and labels lie."""
+        m = self._import()
+        inputs = self._empty_inputs()
+        # Caller passes whatever counts they computed; the helper guarantees
+        # there are exactly 7 day entries in the returned series.
+        inputs["weekly_encounter_counts"] = {"Mon": 18, "Wed": 22}
+        payload = m._format_dashboard(**inputs)
+        self.assertEqual(len(payload["week_volume"]), 7)
+        # And the days that had data are surfaced unchanged.
+        by_day = {row["day"]: row["visits"] for row in payload["week_volume"]}
+        self.assertEqual(by_day["Mon"], 18)
+        self.assertEqual(by_day["Wed"], 22)
+        # The missing days appear with 0, not as absent keys.
+        for day in ("Tue", "Thu", "Fri", "Sat", "Sun"):
+            self.assertEqual(by_day.get(day, "MISSING"), 0,
+                             f"day {day} must default to 0, got {by_day.get(day, 'MISSING')}")
+
+    def test_recent_patients_capped_at_six(self):
+        """The 'Recently seen patients' table is a glance — six rows is the
+        design limit. The helper must enforce it even if the caller hands in
+        more rows, so future query tweaks can't accidentally bloat the table."""
+        m = self._import()
+        inputs = self._empty_inputs()
+        # Twelve fictional rows; only the first six should survive.
+        inputs["recent_patient_rows"] = [
+            {"id": f"PAT-{i:03d}", "name": f"Patient {i}"} for i in range(12)
+        ]
+        payload = m._format_dashboard(**inputs)
+        self.assertEqual(len(payload["recent_patients"]), 6)
+        # The first-six order is preserved (caller is responsible for ordering).
+        self.assertEqual(payload["recent_patients"][0]["id"], "PAT-000")
+        self.assertEqual(payload["recent_patients"][5]["id"], "PAT-005")
+
+    def test_today_appointments_kpi_counts_status_breakdown(self):
+        """The Today's Appointments KPI shows the total plus a status breakdown
+        so the doctor sees, at a glance, how many are confirmed vs still open.
+
+        Patient Appointment uses Frappe Healthcare's real statuses
+        (Confirmed / Open / Scheduled / No Show) — those are what the breakdown
+        labels surface, not the mock's invented 'checked in / in room' which
+        don't exist in the schema.
+        """
+        m = self._import()
+        inputs = self._empty_inputs()
+        inputs["today_appointments"] = [
+            {"id": "A1", "status": "Confirmed", "time": "08:00", "duration": 30,
+             "patient_id": "P1", "patient_name": "Alice", "reason": "Check-up",
+             "practitioner": "Dr X"},
+            {"id": "A2", "status": "Confirmed", "time": "09:00", "duration": 30,
+             "patient_id": "P2", "patient_name": "Bob", "reason": "Follow-up",
+             "practitioner": "Dr X"},
+            {"id": "A3", "status": "Open", "time": "10:00", "duration": 30,
+             "patient_id": "P3", "patient_name": "Carol", "reason": "Consult",
+             "practitioner": "Dr Y"},
+            {"id": "A4", "status": "Scheduled", "time": "11:00", "duration": 30,
+             "patient_id": "P4", "patient_name": "Dan", "reason": "Vaccination",
+             "practitioner": "Dr Y"},
+        ]
+        payload = m._format_dashboard(**inputs)
+        kpi = payload["kpis"]["today_appointments"]
+        self.assertEqual(kpi["value"], 4)
+        # Breakdown surfaces the *real* statuses — at minimum we assert each
+        # observed status is reflected in the breakdown count.
+        self.assertEqual(kpi["breakdown"]["Confirmed"], 2)
+        self.assertEqual(kpi["breakdown"]["Open"], 1)
+        self.assertEqual(kpi["breakdown"]["Scheduled"], 1)
+
+
+class TestGetDashboardEndpoint(unittest.TestCase):
+    """Behavior tests for the whitelisted daystar_health.get_dashboard entry.
+
+    The endpoint is intentionally a thin orchestrator: practice_resolver →
+    DB reads → dashboard_aggregator → return. We test the contract: it must
+    refuse callers without a Practice and produce the documented payload
+    shape on success.
+    """
+
+    def _import(self):
+        from medic_plus.api import daystar_health
+        return daystar_health
+
+    def test_rejects_user_with_no_practice(self):
+        """A logged-in user without a Practice Member row gets PermissionError
+        from the resolver and the endpoint surfaces it unchanged. The SPA
+        translates that into the no-practice error card."""
+        m = self._import()
+        with patch("medic_plus.api.daystar_health.get_active_practice",
+                   side_effect=frappe.PermissionError("no practice")):
+            with self.assertRaises(frappe.PermissionError):
+                m.get_dashboard()
+
+    def test_returns_documented_payload_shape_for_practice_user(self):
+        """The dashboard contract: when a Practice user calls get_dashboard
+        the endpoint returns a dict with greeting, kpis, today_schedule,
+        week_volume, recent_patients, today_label, view_full_schedule_url.
+
+        We mock build_dashboard rather than the DB so this stays an endpoint-
+        level contract test — the aggregator's contents are covered by the
+        format-helper tests above.
+        """
+        m = self._import()
+        fake_payload = {
+            "greeting": "Good morning, Dr. Aiyana",
+            "today_label": "Wednesday, April 29",
+            "kpis": {
+                "today_appointments": {"value": 2, "breakdown": {"Confirmed": 2}},
+                "active_patients": {"value": 41},
+                "outstanding_labs": {"value": 5},
+            },
+            "today_schedule": [],
+            "week_volume": [{"day": "Mon", "visits": 0}] * 7,
+            "recent_patients": [],
+            "view_full_schedule_url": "/app/patient-appointment",
+        }
+        with patch("medic_plus.api.daystar_health.get_active_practice",
+                   return_value="PRAC-00001"), \
+             patch("medic_plus.api.daystar_health.build_dashboard",
+                   return_value=fake_payload) as bd:
+            payload = m.get_dashboard()
+        # The endpoint forwards the aggregator's output; spot-check the
+        # documented top-level keys are present.
+        for key in ("greeting", "kpis", "today_schedule", "week_volume",
+                    "recent_patients", "view_full_schedule_url"):
+            self.assertIn(key, payload, f"missing key: {key}")
+        # And the aggregator was invoked with the resolved Practice (not None
+        # or the user — orchestration contract).
+        bd.assert_called_once()
+        kwargs = bd.call_args.kwargs
+        self.assertEqual(kwargs.get("practice"), "PRAC-00001")

--- a/medic_plus/public/daystar-health/meridian-dashboard.jsx
+++ b/medic_plus/public/daystar-health/meridian-dashboard.jsx
@@ -1,173 +1,220 @@
-// Daystar Health Dashboard ("Today")
+// Daystar Health Dashboard ("Today") — wired to medic_plus.api.daystar_health.get_dashboard.
+// Static MH_DATA mocks have been removed; the screen now hydrates from the
+// Practice-scoped endpoint and renders skeletons during load.
+
 function MDashboardScreen({ go }) {
-  const appts = window.MH_DATA.TODAY_APPTS;
-  const patients = window.MH_DATA.PATIENTS;
+  const [state, setState] = mUseState({ status: 'loading', data: null, error: null });
 
-  const kpis = [
-    { label: 'Today\'s appointments', value: '12', sub: '3 checked in · 1 in room', trend: [8, 10, 12, 9, 11, 13, 12], color: '#2563eb' },
-    { label: 'Active patients', value: '1,284', sub: '+18 this month', trend: [50, 53, 56, 60, 63, 66, 70], color: '#10b981' },
-    { label: 'Outstanding labs', value: '23', sub: '4 critical results', trend: [18, 20, 19, 22, 21, 24, 23], color: '#f59e0b' },
-    { label: 'Pending refills', value: '38', sub: '12 awaiting review', trend: [30, 32, 36, 34, 40, 38, 38], color: '#8b5cf6' },
-  ];
+  mUseEffect(() => {
+    let cancelled = false;
+    setState({ status: 'loading', data: null, error: null });
+    window.meridianApi
+      .call('medic_plus.api.daystar_health.get_dashboard')
+      .then((data) => { if (!cancelled) setState({ status: 'ready', data, error: null }); })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({ status: 'error', data: null, error: err.message || 'Could not load dashboard.' });
+        window.meridianApi.showError(err.message || 'Could not load dashboard.');
+      });
+    return () => { cancelled = true; };
+  }, []);
 
-  const week = [
-    { d: 'Mon', visits: 18 }, { d: 'Tue', visits: 22 }, { d: 'Wed', visits: 19 },
-    { d: 'Thu', visits: 24 }, { d: 'Fri', visits: 21 }, { d: 'Sat', visits: 8 }, { d: 'Sun', visits: 0 },
-  ];
+  if (state.status === 'loading') return <DashboardSkeleton />;
+  if (state.status === 'error') return <DashboardError message={state.error} />;
+  return <DashboardReady go={go} data={state.data} />;
+}
 
+function DashboardSkeleton() {
   return (
-    <div className="page fade-in">
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 24, gap: 16, flexWrap: 'wrap' }}>
-        <div>
-          <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 4px', letterSpacing: '-0.02em' }}>
-            Good morning, Dr. Patel
-          </h1>
-          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>Wednesday, April 29 · {appts.length} patients on your schedule today.</p>
-        </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button className="btn btn-secondary btn-sm"><window.MIcons.Calendar size={14} /> View full schedule</button>
-          <button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> New appointment</button>
-        </div>
+    <div className="page fade-in" data-testid="dashboard-skeleton">
+      <div style={{ marginBottom: 24 }}>
+        <SkeletonBar w={260} h={26} />
+        <div style={{ height: 8 }} />
+        <SkeletonBar w={360} h={14} />
       </div>
-
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
-        {kpis.map((k, i) => (
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
+        {[0, 1, 2].map(i => (
           <div key={i} className="kpi-tile">
-            <div className="kpi-label">{k.label}</div>
-            <div className="kpi-value">{k.value}</div>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
-              <span style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{k.sub}</span>
-              <div style={{ width: 70 }}><window.Sparkline data={k.trend} color={k.color} height={26} /></div>
-            </div>
+            <SkeletonBar w={120} h={12} />
+            <div style={{ height: 8 }} />
+            <SkeletonBar w={80} h={26} />
           </div>
         ))}
       </div>
+      <div className="card card-pad"><SkeletonBar w="100%" h={140} /></div>
+    </div>
+  );
+}
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1.6fr 1fr', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
-        {/* Today's schedule */}
-        <div className="card">
-          <div className="card-header">
-            <div>
-              <h3 className="card-title">Today's schedule</h3>
-              <div style={{ fontSize: 11.5, color: 'var(--text-muted)', marginTop: 2 }}>Wed, Apr 29 · Dr. Patel & Dr. Okafor</div>
-            </div>
-            <div className="segment">
-              <button className="active">Day</button>
-              <button>Week</button>
-              <button>Month</button>
-            </div>
-          </div>
-          <div>
-            {appts.map((a, i) => (
-              <div key={i} onClick={() => go('patient', a.id)} style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '12px 20px', borderBottom: i < appts.length - 1 ? '1px solid var(--border)' : 'none', cursor: 'pointer' }}>
-                <div style={{ width: 60, flexShrink: 0 }}>
-                  <div className="mono" style={{ fontSize: 13, fontWeight: 600 }}>{a.time}</div>
-                  <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-dim)' }}>{a.dur} min</div>
-                </div>
-                <div style={{ width: 3, height: 36, background: a.kind === 'urgent' ? 'var(--danger)' : a.kind === 'followup' ? 'var(--info)' : 'var(--accent)', borderRadius: 2 }} />
-                <div className="avatar avatar-sm" style={{ width: 32, height: 32, fontSize: 11 }}>
-                  {a.patient.split(' ').map(n => n[0]).join('')}
-                </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 13.5, fontWeight: 500 }}>{a.patient}</div>
-                  <div style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{a.reason} · {a.provider} · {a.room}</div>
-                </div>
-                <span className={`badge ${a.status === 'In room' ? 'badge-info' : a.status === 'Checked in' ? 'badge-success' : 'badge-neutral'}`}>{a.status}</span>
-              </div>
-            ))}
-          </div>
+function SkeletonBar({ w = '100%', h = 14 }) {
+  return <div style={{ width: w, height: h, background: 'var(--bg-subtle)', borderRadius: 4, animation: 'pulse 1.6s infinite' }} />;
+}
+
+function DashboardError({ message }) {
+  return (
+    <div className="page fade-in">
+      <div className="card card-pad" data-testid="dashboard-error" style={{ textAlign: 'center', padding: 60 }}>
+        <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 8px' }}>Couldn't load dashboard</h2>
+        <p style={{ fontSize: 13, color: 'var(--text-muted)' }}>{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function DashboardReady({ go, data }) {
+  const today = data.today_schedule || [];
+  const recent = data.recent_patients || [];
+  const week = data.week_volume || [];
+  const apptKpi = (data.kpis && data.kpis.today_appointments) || { value: 0, breakdown: {} };
+  const activeKpi = (data.kpis && data.kpis.active_patients) || { value: 0 };
+  const labKpi = (data.kpis && data.kpis.outstanding_labs) || { value: 0 };
+  const subtitleParts = Object.entries(apptKpi.breakdown || {}).map(([k, v]) => `${v} ${k.toLowerCase()}`);
+  const subtitleText = subtitleParts.length ? subtitleParts.join(' · ') : 'No appointments today';
+
+  return (
+    <div className="page fade-in" data-testid="dashboard-ready">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 24, gap: 16, flexWrap: 'wrap' }}>
+        <div>
+          <h1 data-testid="dashboard-greeting" style={{ fontSize: 22, fontWeight: 600, margin: '0 0 4px', letterSpacing: '-0.02em' }}>
+            {data.greeting}
+          </h1>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{data.today_label} · {today.length} patients on your schedule today.</p>
         </div>
-
-        {/* Right column: alerts + week chart */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
-          <div className="card">
-            <div className="card-header">
-              <h3 className="card-title">Needs attention</h3>
-              <span className="badge badge-warn">5</span>
-            </div>
-            <div>
-              {[
-                { icon: 'AlertTriangle', tone: 'urgent', who: 'James Whitaker', what: 'BP 142/94 — above target', when: '20 min ago', id: 'MH-10341' },
-                { icon: 'Beaker', tone: 'watch', who: 'Eleanor Chen', what: 'A1c result requires review', when: '1h ago', id: 'MH-10042' },
-                { icon: 'Pill', tone: 'watch', who: 'Robert Kim', what: 'Refill request: Tiotropium', when: '2h ago', id: 'MH-10744' },
-                { icon: 'Mail', tone: 'normal', who: 'Marcus Rivera', what: 'Sent inhaler technique question', when: '3h ago', id: 'MH-10118' },
-              ].map((a, i, arr) => {
-                const Ic = window.MIcons[a.icon];
-                const tone = a.tone === 'urgent' ? '#ef4444' : a.tone === 'watch' ? '#f59e0b' : '#3b82f6';
-                return (
-                  <div key={i} onClick={() => go('patient', a.id)} style={{ display: 'flex', gap: 10, padding: '12px 16px', borderBottom: i < arr.length - 1 ? '1px solid var(--border)' : 'none', cursor: 'pointer' }}>
-                    <div style={{ width: 28, height: 28, borderRadius: 8, background: a.tone === 'urgent' ? 'var(--danger-soft)' : a.tone === 'watch' ? 'var(--warn-soft)' : 'var(--info-soft)', display: 'grid', placeItems: 'center', flexShrink: 0 }}>
-                      <Ic size={14} stroke={tone} />
-                    </div>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: 12.5, fontWeight: 500 }}>{a.who}</div>
-                      <div style={{ fontSize: 11.5, color: 'var(--text-muted)' }}>{a.what}</div>
-                    </div>
-                    <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>{a.when}</div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-
-          <div className="card card-pad">
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 14 }}>
-              <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: 0 }}>This week's volume</h3>
-              <span className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>112 visits</span>
-            </div>
-            <svg viewBox="0 0 280 100" style={{ width: '100%', height: 100 }}>
-              {week.map((d, i) => {
-                const max = Math.max(...week.map(w => w.visits)) || 1;
-                const h = (d.visits / max) * 70;
-                const x = 20 + i * 36;
-                return (
-                  <g key={i}>
-                    <rect x={x} y={80 - h} width="22" height={h} fill="var(--accent)" rx="3" opacity={i === 2 ? 1 : 0.55} />
-                    <text x={x + 11} y="94" textAnchor="middle" fontSize="9" fill="var(--text-dim)" fontFamily="var(--font-mono)">{d.d}</text>
-                    <text x={x + 11} y={76 - h} textAnchor="middle" fontSize="9" fill="var(--text-muted)" fontFamily="var(--font-mono)">{d.visits || ''}</text>
-                  </g>
-                );
-              })}
-            </svg>
-          </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <a className="btn btn-secondary btn-sm" href={data.view_full_schedule_url} target="_blank" rel="noreferrer" data-testid="view-full-schedule">
+            <window.MIcons.Calendar size={14} /> View full schedule
+          </a>
         </div>
       </div>
 
-      {/* Bottom: recent patients */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
+        <KpiTile label="Today's appointments" value={apptKpi.value} subtitle={subtitleText} testId="kpi-today-appointments" />
+        <KpiTile label="Active patients" value={activeKpi.value} subtitle="Across the practice" testId="kpi-active-patients" />
+        <KpiTile label="Outstanding labs" value={labKpi.value} subtitle="Open or in progress" testId="kpi-outstanding-labs" />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1.6fr 1fr', gap: 'var(--gap)', marginBottom: 'var(--gap)' }}>
+        <TodaysSchedule today={today} go={go} todayLabel={data.today_label} />
+        <WeekVolumeCard week={week} />
+      </div>
+
       <div className="card">
         <div className="card-header">
           <h3 className="card-title">Recently seen patients</h3>
           <button className="btn btn-ghost btn-sm" onClick={() => go('patients')}>All patients</button>
         </div>
-        <div style={{ overflowX: 'auto' }}>
-          <table className="table">
-            <thead>
-              <tr><th>Patient</th><th>MRN</th><th>Last visit</th><th>Conditions</th><th>Risk</th><th>Status</th><th>Next appt</th></tr>
-            </thead>
-            <tbody>
-              {patients.slice(0, 6).map(p => (
-                <tr key={p.id} onClick={() => go('patient', p.id)}>
-                  <td>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                      <div className="avatar avatar-sm" style={{ width: 28, height: 28, fontSize: 10 }}>{p.name.split(' ').map(n => n[0]).join('')}</div>
-                      <div>
-                        <div style={{ fontWeight: 500 }}>{p.name}</div>
-                        <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>{p.age} {p.sex} · {p.primary}</div>
+        <div style={{ overflowX: 'auto' }} data-testid="recent-patients">
+          {recent.length === 0 ? (
+            <div style={{ padding: 40, textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+              No patient encounters yet.
+            </div>
+          ) : (
+            <table className="table">
+              <thead>
+                <tr><th>Patient</th><th>Last visit</th></tr>
+              </thead>
+              <tbody>
+                {recent.map(p => (
+                  <tr key={p.id} onClick={() => go('patient', p.id)}>
+                    <td>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                        <div className="avatar avatar-sm" style={{ width: 28, height: 28, fontSize: 10 }}>
+                          {(p.name || '?').split(' ').map(n => n[0]).join('').slice(0, 2)}
+                        </div>
+                        <div>
+                          <div style={{ fontWeight: 500 }}>{p.name || '—'}</div>
+                          <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>
+                            {p.age != null ? `${p.age}` : '—'} {p.sex || ''}
+                          </div>
+                        </div>
                       </div>
-                    </div>
-                  </td>
-                  <td className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{p.mrn}</td>
-                  <td>{p.lastSeen}</td>
-                  <td style={{ fontSize: 12, color: 'var(--text-muted)' }}>{p.conditions.slice(0, 2).join(', ') || '—'}</td>
-                  <td><span className={`badge ${p.risk === 'High' ? 'badge-danger' : p.risk === 'Moderate' ? 'badge-warn' : 'badge-success'}`}>{p.risk}</span></td>
-                  <td><span className={`badge ${p.status === 'Stable' ? 'pill-stable' : p.status === 'Watch' ? 'pill-watch' : 'pill-urgent'}`} style={{ background: p.status === 'Stable' ? 'var(--success-soft)' : p.status === 'Watch' ? 'var(--warn-soft)' : 'var(--danger-soft)' }}>{p.status}</span></td>
-                  <td className="mono" style={{ fontSize: 12 }}>{p.nextAppt}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                    </td>
+                    <td>{p.last_seen || '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function KpiTile({ label, value, subtitle, testId }) {
+  return (
+    <div className="kpi-tile" data-testid={testId}>
+      <div className="kpi-label">{label}</div>
+      <div className="kpi-value">{value}</div>
+      <div style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{subtitle}</div>
+    </div>
+  );
+}
+
+function TodaysSchedule({ today, go, todayLabel }) {
+  return (
+    <div className="card">
+      <div className="card-header">
+        <div>
+          <h3 className="card-title">Today's schedule</h3>
+          <div style={{ fontSize: 11.5, color: 'var(--text-muted)', marginTop: 2 }}>{todayLabel}</div>
+        </div>
+      </div>
+      <div data-testid="today-schedule">
+        {today.length === 0 ? (
+          <div style={{ padding: 40, textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+            No appointments scheduled for today.
+          </div>
+        ) : today.map((a, i) => (
+          <div key={a.id} onClick={() => go('patient', a.patient_id)} style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '12px 20px', borderBottom: i < today.length - 1 ? '1px solid var(--border)' : 'none', cursor: 'pointer' }}>
+            <div style={{ width: 60, flexShrink: 0 }}>
+              <div className="mono" style={{ fontSize: 13, fontWeight: 600 }}>{a.time}</div>
+              <div className="mono" style={{ fontSize: 10.5, color: 'var(--text-dim)' }}>{a.duration} min</div>
+            </div>
+            <div className="avatar avatar-sm" style={{ width: 32, height: 32, fontSize: 11 }}>
+              {(a.patient_name || '?').split(' ').map(n => n[0]).join('').slice(0, 2)}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13.5, fontWeight: 500 }}>{a.patient_name}</div>
+              <div style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{a.reason || '—'} · {a.practitioner}</div>
+            </div>
+            <span className={`badge ${badgeClass(a.status)}`}>{a.status}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function badgeClass(status) {
+  if (status === 'Confirmed') return 'badge-success';
+  if (status === 'Open') return 'badge-info';
+  if (status === 'No Show') return 'badge-danger';
+  return 'badge-neutral';
+}
+
+function WeekVolumeCard({ week }) {
+  const total = week.reduce((sum, d) => sum + (d.visits || 0), 0);
+  const max = Math.max(1, ...week.map(d => d.visits || 0));
+  return (
+    <div className="card card-pad">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 14 }}>
+        <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: 0 }}>This week's volume</h3>
+        <span className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{total} visits</span>
+      </div>
+      <svg viewBox="0 0 280 100" style={{ width: '100%', height: 100 }} data-testid="week-volume">
+        {week.map((d, i) => {
+          const h = ((d.visits || 0) / max) * 70;
+          const x = 20 + i * 36;
+          return (
+            <g key={d.day}>
+              <rect x={x} y={80 - h} width="22" height={h} fill="var(--accent)" rx="3" opacity={d.visits ? 1 : 0.3} />
+              <text x={x + 11} y="94" textAnchor="middle" fontSize="9" fill="var(--text-dim)" fontFamily="var(--font-mono)">{d.day}</text>
+              <text x={x + 11} y={76 - h} textAnchor="middle" fontSize="9" fill="var(--text-muted)" fontFamily="var(--font-mono)">{d.visits || ''}</text>
+            </g>
+          );
+        })}
+      </svg>
     </div>
   );
 }

--- a/medic_plus/tests/ui/test_daystar_health.py
+++ b/medic_plus/tests/ui/test_daystar_health.py
@@ -1,18 +1,24 @@
 """
-UI Tests: Daystar Health SPA — auth flow (Issue #4)
-====================================================
+UI Tests: Daystar Health SPA — auth flow (Issue #4) and dashboard (Issue #5)
+============================================================================
 
 Behaviors tested:
-  1. Anonymous visit to /daystar-health renders the SPA login screen.
-  2. Submitting bad credentials surfaces an in-page error.
-  3. Submitting valid credentials reloads to the post-login screen.
-  4. An already-logged-in user without a Practice Member row sees the
-     "Practice not linked" error card.
-  5. Sign-out on the no-practice card returns the user to the login screen.
+  Auth flow (slice 1):
+    1. Anonymous visit to /daystar-health renders the SPA login screen.
+    2. Submitting bad credentials surfaces an in-page error.
+    3. Submitting valid credentials reloads to the post-login screen.
+    4. An already-logged-in user without a Practice Member row sees the
+       "Practice not linked" error card.
+    5. Sign-out on the no-practice card returns the user to the login screen.
 
-Administrator has no Practice Member row on this site, which makes them the
-perfect fixture for the no-practice path. Test 3 asserts the post-login render
-(either dashboard or no-practice card) — proving the login wire round-trips.
+  Dashboard (slice 2):
+    6. An authenticated user *with* a Practice Member row sees the dashboard
+       render with KPI tiles and a week-volume chart hydrated from real data.
+
+Administrator has no Practice Member row on this site by default, which makes
+them the perfect fixture for the no-practice path. The slice 2 dashboard test
+adds a temporary Practice Member row for Administrator and tears it down
+afterwards.
 """
 
 import re
@@ -98,3 +104,84 @@ class TestNoPracticeSignOut:
         # as Guest → login screen.
         expect(page.locator('[data-testid="login-email"]')).to_be_visible(timeout=15_000)
         expect(page.locator('[data-testid="no-practice-card"]')).not_to_be_visible()
+
+
+# ── slice 2: dashboard ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def admin_with_practice_membership():
+    """Temporarily make Administrator a Practice Member of PRAC-00001.
+
+    The Daystar Health SPA gates dashboard access on Practice membership. We
+    need a logged-in user *with* a Practice for the dashboard test, but the
+    site only has Administrator with known credentials. This fixture inserts
+    the membership row before the test and removes it on teardown so other
+    tests (which assume Administrator has no Practice) keep passing.
+    """
+    import os
+    os.chdir('/home/fruppa/frappe-bench/sites')
+    import frappe
+    frappe.init(site='medic-demo-staging.thedaystar.co.za')
+    frappe.connect()
+
+    practice = "PRAC-00001"
+    # Use 'Admin' role: Practice Member validation requires a Healthcare
+    # Practitioner link when role=Doctor, which Administrator doesn't have.
+    member = frappe.get_doc({
+        "doctype": "Practice Member",
+        "user": "Administrator",
+        "practice": practice,
+        "role": "Admin",
+        "status": "Accepted",
+        "full_name": "Test Administrator",
+        "email": "Administrator",
+    })
+    member.insert(ignore_permissions=True)
+    frappe.db.commit()
+    yield {"practice": practice, "member_name": member.name}
+    frappe.delete_doc("Practice Member", member.name, ignore_permissions=True, force=True)
+    frappe.db.commit()
+    frappe.destroy()
+
+
+class TestDashboardRender:
+    """The dashboard hydrates from medic_plus.api.daystar_health.get_dashboard
+    and surfaces the three KPI tiles, a week-volume chart, and the recent
+    patients table — all scoped to the user's Practice."""
+
+    def test_practice_user_sees_dashboard_with_kpis(self, admin_with_practice_membership, page: Page):
+        # Log in as admin (now a Practice Member of PRAC-00001).
+        page.goto(f"{BASE_URL}/login")
+        page.locator("#login_email").fill(ADMIN_USER)
+        page.locator("#login_password").fill(ADMIN_PASS)
+        page.locator(".btn-login[type='submit']").click()
+        page.wait_for_url(re.compile(r"/(app|desk)"), timeout=15_000)
+
+        page.goto(DAYSTAR_URL)
+        # Skeleton appears first, then resolves to the ready state.
+        expect(page.locator('[data-testid="dashboard-ready"]')).to_be_visible(timeout=20_000)
+
+        # All three KPI tiles render (numbers vary by data; we just assert
+        # the tiles are present, not their values).
+        expect(page.locator('[data-testid="kpi-today-appointments"]')).to_be_visible()
+        expect(page.locator('[data-testid="kpi-active-patients"]')).to_be_visible()
+        expect(page.locator('[data-testid="kpi-outstanding-labs"]')).to_be_visible()
+
+        # The week-volume chart renders 7 day bars (svg <text> labels).
+        expect(page.locator('[data-testid="week-volume"]')).to_be_visible()
+
+        # Today's schedule and recent-patients sections both render their
+        # container — even when empty they show an empty-state message.
+        expect(page.locator('[data-testid="today-schedule"]')).to_be_visible()
+        expect(page.locator('[data-testid="recent-patients"]')).to_be_visible()
+
+        # Greeting addresses the user (Administrator's first_name happens to
+        # be 'Administrator' on a fresh site, so we just check the testid).
+        expect(page.locator('[data-testid="dashboard-greeting"]')).to_be_visible()
+
+        # "View full schedule" link points at the Frappe Desk Patient
+        # Appointment list scoped to today + this Practice.
+        href = page.locator('[data-testid="view-full-schedule"]').get_attribute("href")
+        assert href and "/app/patient-appointment" in href, f"unexpected href: {href}"
+        assert "PRAC-00001" in href, f"href missing practice scope: {href}"

--- a/techspec.md
+++ b/techspec.md
@@ -4,6 +4,38 @@ Living technical specification. Every feature, bugfix, refactor, and design deci
 
 ---
 
+## 2026-04-29 — Phase 1G (Issue #5): Daystar Health dashboard — wired to live Practice data
+
+### Scope
+Slice 2 of 5 wiring `/daystar-health`. Replaces the static `MH_DATA` constants on the dashboard screen with a real composite endpoint scoped to the user's active Practice.
+
+### Deep module: `dashboard_aggregator`
+- `build_dashboard(*, practice, user)` — orchestrator. Resolves the user's first name, runs Practice-scoped queries against Patient Appointment / Patient / Lab Test / Patient Encounter, then delegates to the format helper.
+- `_format_dashboard(...)` — pure transformation. Takes already-fetched values and returns the payload dict. Tested in isolation without a DB so the interesting rules (greeting personalisation, week-volume always 7 days, recent-patients cap at 6, status breakdown of today's appointments) have fast unit coverage.
+
+### Endpoint: `daystar_health.get_dashboard()`
+- Thin orchestrator: `practice_resolver.get_active_practice` → `build_dashboard` → return. Surfaces `frappe.PermissionError` unchanged so the SPA can render the no-practice card.
+
+### Frontend rewire (`meridian-dashboard.jsx`)
+- On mount, `meridianApi.call('medic_plus.api.daystar_health.get_dashboard')`. Skeleton placeholder during load; toast + inline error card on failure.
+- KPI tiles: today's appointments (with status-breakdown subtitle using *real* statuses — Confirmed / Open / Scheduled — not the mock's "checked-in / in-room"), active patients, outstanding labs.
+- Today's schedule, week-volume bar chart, recent-patients table all hydrate from the payload.
+- Per Q9 design decision: dropped the "Pending refills" KPI tile (no Frappe backing), the "Needs attention" alerts panel (no backing), the MRN/Risk/Status columns on recent patients, the Day/Week/Month toggle, and the "New appointment" button.
+- "View full schedule" button links to the Frappe Desk Patient Appointment list filtered by `custom_practice` and today's `appointment_date`.
+
+### Schema realities handled
+- `Lab Test` has no `custom_practice` field. The outstanding-labs KPI uses a JOIN through `Patient.custom_practice` rather than schema migration.
+- The `checked_in / in_room` statuses in the mock don't exist in `Patient Appointment`. The real statuses (`Confirmed / No Show / Open / Scheduled`) are surfaced verbatim.
+
+### Tests
+- Python (`api/test_daystar_health.py`): 4 format-helper unit tests + 2 endpoint contract tests (no-Practice rejection, payload shape on success). Mocks at the boundary so the helper is testable without DB or session.
+- Playwright (`tests/ui/test_daystar_health.py`): one test that creates a temporary `Practice Member` row for Administrator (role=Admin to bypass the Doctor → Healthcare Practitioner validation), logs in, asserts the dashboard renders all three KPI tiles, the week-volume chart, today-schedule and recent-patients sections, the greeting block, and the "View full schedule" link with the right `custom_practice` query string. Tears the Practice Member row down on teardown so the slice 1 no-practice tests still pass for Administrator.
+
+### Out of scope (later slices)
+- Patients list (#6), patient detail composite (#7), profile + password change (#8).
+
+---
+
 ## 2026-04-29 — Phase 1F (Issue #4): Daystar Health SPA — auth flow wired to Frappe
 
 ### Scope


### PR DESCRIPTION
Closes #5. Slice 2 of 5 wiring the `/daystar-health` SPA. Replaces the static `MH_DATA`-driven dashboard with a real composite endpoint scoped to the user's active Practice.

## Summary

- **Deep module** `api/dashboard_aggregator` — `build_dashboard(practice, user)` orchestrator + a pure `_format_dashboard(...)` helper for testable shaping rules (greeting personalisation, week-volume always 7 days, recent-patients cap of 6, today-appointment status breakdown using the *real* Healthcare statuses).
- **Endpoint** `medic_plus.api.daystar_health.get_dashboard` — thin orchestrator. Surfaces `frappe.PermissionError` from `practice_resolver` unchanged.
- **Dashboard screen rewrite** — three render states (skeleton / error / ready) with three KPI tiles, today's schedule, week-volume bar chart, recent-patients table.

## Schema realities handled

- `Lab Test` has no `custom_practice` field — outstanding-labs KPI uses a JOIN through `Patient.custom_practice` rather than schema migration.
- The mock's "checked-in / in-room" status breakdown doesn't exist in `Patient Appointment` (real statuses are `Confirmed / No Show / Open / Scheduled`). The KPI subtitle surfaces real statuses verbatim.

## Per the design decisions in the issue

Removed: "Pending refills" KPI tile, "Needs attention" alerts panel, MRN/Risk/Status columns on recent patients, Day/Week/Month toggle, "New appointment" button. "View full schedule" links to Frappe Desk Patient Appointment list scoped to today + Practice.

## Test plan

- [x] `env/bin/python -m pytest apps/medic_plus/medic_plus/api/test_daystar_health.py -v` — 9 passed (3 resolver + 4 format helper + 2 endpoint contract)
- [x] `env/bin/python -m pytest apps/medic_plus/medic_plus/tests/ui/test_daystar_health.py -v` — 6 passed (5 auth flow from #4 + 1 dashboard render)
- [x] Manual: a Practice Member can sign in and see KPIs, today's schedule, week-volume, and recent patients hydrated from real data.

## Out of scope (later slices)

Patients list (#6), patient detail composite (#7), profile + password change (#8) — all still consume static `MH_DATA` mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)