### PR TITLE
Wire Daystar Health patient detail to composite endpoint (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ MIT
 
 ## Changelog
 
+### 2026-04-29 — Phase 1I (Issue #7): Daystar Health patient detail wired to composite endpoint
+- Slice 4 of 5 wiring the `/daystar-health` SPA. Patient detail screen now hydrates all six tabs (Overview / Visits / Vitals / Medications / Labs / Notes) from a single composite call.
+- New deep module `api/patient_summary` — `build_patient_summary(patient_name, practice)` orchestrator + pure `_format_patient_summary(...)` helper that applies per-tab caps (20 / 12 for vitals) and the POPIA whitelist (only `name / patient_name / dob / sex / mobile / email / status` make it into the patient block; `custom_sa_id_number` is unreachable).
+- New whitelisted endpoint `medic_plus.api.daystar_health.get_patient_detail(patient)` — looks up the patient's `custom_practice` and raises `frappe.PermissionError` for cross-tenant requests, then returns the composite. Same error class as no-practice so callers cannot probe Practice membership.
+- Tests: 4 Python (POPIA, per-tab caps, no-practice rejection, cross-tenant rejection) + 2 Playwright (detail loads all 6 tab containers; response body asserted POPIA-clean).
+- Surfaced Issue #12: Practice Admin / Doctor / Receptionist roles don't have read permission on Patient via Custom DocPerm — workaround in place (Physician role on selfserve.test).
+
 ### 2026-04-29 — Phase 1H (Issue #6): Daystar Health patients list wired to REST resource API
 - Slice 3 of 5 wiring the `/daystar-health` SPA. Patients screen now hydrates from `/api/resource/Patient` instead of `MH_DATA` mocks.
 - Server-side pagination (real `limit_start/limit_page_length/total`), 300ms-debounced search across `patient_name/mobile/email` via `or_filters`, sortable headers (`patient_name`, `dob`), page-size selector (25/50/100) persisted in `sessionStorage`. Skeleton + error + empty-state UI.

--- a/medic_plus/api/daystar_health.py
+++ b/medic_plus/api/daystar_health.py
@@ -14,6 +14,7 @@ patient_summary, …) so it can be tested in isolation.
 import frappe
 
 from medic_plus.api.dashboard_aggregator import build_dashboard
+from medic_plus.api.patient_summary import build_patient_summary
 from medic_plus.api.practice_resolver import get_active_practice
 
 
@@ -22,3 +23,18 @@ def get_dashboard() -> dict:
     """Return the dashboard payload for the logged-in user's active Practice."""
     practice = get_active_practice()
     return build_dashboard(practice=practice, user=frappe.session.user)
+
+
+@frappe.whitelist()
+def get_patient_detail(patient: str) -> dict:
+    """Return the composite payload for a Patient detail screen.
+
+    Cross-tenant guard: the requested Patient must belong to the caller's
+    active Practice. Cross-Practice requests raise PermissionError so the
+    response cannot be used to probe Practice membership of arbitrary IDs.
+    """
+    practice = get_active_practice()
+    patient_practice = frappe.db.get_value("Patient", patient, "custom_practice")
+    if patient_practice != practice:
+        raise frappe.PermissionError("Patient does not belong to your practice.")
+    return build_patient_summary(patient_name=patient, practice=practice)

--- a/medic_plus/api/patient_summary.py
+++ b/medic_plus/api/patient_summary.py
@@ -1,0 +1,205 @@
+"""Compose the Daystar Health patient detail composite payload.
+
+The deep module orchestrates DB reads + payload shaping for the patient
+detail screen. The screen has six tabs (Overview / Visits / Vitals /
+Medications / Labs / Notes); the composite returns all six in one round
+trip, with per-tab caps and POPIA whitelisting applied.
+
+POPIA: the format helper explicitly whitelists the patient core fields it
+returns. Fields like ``custom_sa_id_number`` never appear in the payload —
+no unmask flow this iteration; the SA ID is simply unreachable from the SPA.
+"""
+
+from urllib.parse import urlencode
+
+import frappe
+from frappe.utils import format_date, format_datetime
+
+
+def build_patient_summary(*, patient_name: str, practice: str) -> dict:
+    """Compose the Daystar Health patient detail payload for a given Patient.
+
+    Caller is responsible for the cross-tenant guard — by the time this is
+    invoked, ``patient_name`` is known to belong to ``practice``. We don't
+    re-check here so the deep module stays focused on shaping the payload.
+    """
+    patient_row = frappe.db.get_value(
+        "Patient",
+        patient_name,
+        list(_PATIENT_PUBLIC_FIELDS),
+        as_dict=True,
+    ) or frappe._dict()
+
+    visits = [
+        {
+            "id": r.name,
+            "date": format_date(r.encounter_date) if r.encounter_date else "",
+            "type": r.appointment_type or "",
+            "practitioner": r.practitioner_name or r.practitioner or "",
+            "department": r.medical_department or "",
+            "comment": r.encounter_comment or "",
+        }
+        for r in frappe.db.get_all(
+            "Patient Encounter",
+            filters={"patient": patient_name},
+            fields=["name", "encounter_date", "appointment_type",
+                    "practitioner", "practitioner_name", "medical_department",
+                    "encounter_comment"],
+            order_by="encounter_date desc",
+            limit_page_length=_VISITS_CAP,
+        )
+    ]
+
+    vitals = [
+        {
+            "id": r.name,
+            "date": format_date(r.signs_date) if r.signs_date else "",
+            "bp_systolic": r.bp_systolic,
+            "bp_diastolic": r.bp_diastolic,
+            "weight": r.weight,
+            "temperature": r.temperature,
+            "respiratory_rate": r.respiratory_rate,
+        }
+        for r in frappe.db.get_all(
+            "Vital Signs",
+            filters={"patient": patient_name},
+            fields=["name", "signs_date", "bp_systolic", "bp_diastolic",
+                    "weight", "temperature", "respiratory_rate"],
+            order_by="signs_date desc, signs_time desc",
+            limit_page_length=_VITALS_CAP,
+        )
+    ]
+
+    # Active medications: de-duplicate prescriptions by drug across recent
+    # encounters. Most recent prescription wins.
+    seen_drugs: set = set()
+    medications: list = []
+    rx_rows = frappe.db.sql(
+        """
+        SELECT dp.drug_code, dp.drug_name, dp.dosage, dp.period,
+               dp.dosage_form, dp.interval, e.encounter_date AS started
+        FROM `tabDrug Prescription` dp
+        INNER JOIN `tabPatient Encounter` e ON e.name = dp.parent
+        WHERE e.patient = %(patient)s
+        ORDER BY e.encounter_date DESC, dp.idx ASC
+        """,
+        {"patient": patient_name},
+        as_dict=True,
+    )
+    for r in rx_rows:
+        key = r.get("drug_code") or r.get("drug_name") or ""
+        if key in seen_drugs:
+            continue
+        seen_drugs.add(key)
+        medications.append({
+            "id": key,
+            "name": r.get("drug_name") or r.get("drug_code") or "",
+            "dosage": r.get("dosage") or "",
+            "period": r.get("period") or "",
+            "dosage_form": r.get("dosage_form") or "",
+            "interval": r.get("interval") or "",
+            "started": format_date(r.get("started")) if r.get("started") else "",
+        })
+        if len(medications) >= _MEDICATIONS_CAP:
+            break
+
+    labs = [
+        {
+            "id": r.name,
+            "template": r.template or "",
+            "status": r.status or "",
+            "result_date": format_date(r.result_date) if r.result_date else "",
+        }
+        for r in frappe.db.get_all(
+            "Lab Test",
+            filters={"patient": patient_name},
+            fields=["name", "template", "status", "result_date"],
+            order_by="result_date desc",
+            limit_page_length=_LABS_CAP,
+        )
+    ]
+
+    notes = [
+        {
+            "id": r.name,
+            "author": r.comment_email or r.owner or "",
+            "when": format_datetime(r.creation) if r.creation else "",
+            "body": r.content or "",
+        }
+        for r in frappe.db.get_all(
+            "Comment",
+            filters={
+                "reference_doctype": "Patient",
+                "reference_name": patient_name,
+                "comment_type": "Comment",
+            },
+            fields=["name", "comment_email", "owner", "creation", "content"],
+            order_by="creation desc",
+            limit_page_length=_NOTES_CAP,
+        )
+    ]
+
+    return _format_patient_summary(
+        patient_row=patient_row,
+        visits=visits,
+        vitals=vitals,
+        medications=medications,
+        labs=labs,
+        notes=notes,
+        full_record_links=_full_record_links(patient_name, practice),
+    )
+
+
+def _full_record_links(patient: str, practice: str) -> dict:
+    """Frappe Desk URLs for the 'see full record' links on each tab."""
+    p = urlencode({"patient": patient})
+    return {
+        "visits": f"/app/patient-encounter?{p}",
+        "vitals": f"/app/vital-signs?{p}",
+        "medications": f"/app/patient-encounter?{p}",  # drug history per encounter
+        "labs": f"/app/lab-test?{p}",
+        "notes": f"/app/patient/{patient}",  # comment activity feed lives on the doc
+    }
+
+
+# Patient fields surfaced to the SPA. Anything outside this list is dropped,
+# regardless of what the caller hands in. This is the POPIA whitelist.
+_PATIENT_PUBLIC_FIELDS = (
+    "name",
+    "patient_name",
+    "dob",
+    "sex",
+    "mobile",
+    "email",
+    "status",
+)
+
+# Per-tab row caps. Vitals is shorter because the trend chart in the SPA
+# renders exactly 12 data points; the others are bounded for payload size.
+_VISITS_CAP = 20
+_VITALS_CAP = 12
+_MEDICATIONS_CAP = 20
+_LABS_CAP = 20
+_NOTES_CAP = 20
+
+
+def _format_patient_summary(
+    *,
+    patient_row: dict,
+    visits: list,
+    vitals: list,
+    medications: list,
+    labs: list,
+    notes: list,
+    full_record_links: dict | None = None,
+) -> dict:
+    patient = {k: patient_row.get(k) for k in _PATIENT_PUBLIC_FIELDS if k in patient_row}
+    return {
+        "patient": patient,
+        "visits": list(visits)[:_VISITS_CAP],
+        "vitals": list(vitals)[:_VITALS_CAP],
+        "medications": list(medications)[:_MEDICATIONS_CAP],
+        "labs": list(labs)[:_LABS_CAP],
+        "notes": list(notes)[:_NOTES_CAP],
+        "full_record_links": full_record_links or {},
+    }

--- a/medic_plus/api/test_daystar_health.py
+++ b/medic_plus/api/test_daystar_health.py
@@ -256,6 +256,43 @@ class TestGetDashboardEndpoint(unittest.TestCase):
         self.assertEqual(kwargs.get("practice"), "PRAC-00001")
 
 
+class TestGetPatientDetailEndpoint(unittest.TestCase):
+    """Behavior tests for the whitelisted daystar_health.get_patient_detail.
+
+    The endpoint orchestrates: practice_resolver → cross-tenant guard
+    (the requested patient must belong to the user's Practice) →
+    build_patient_summary → return.
+    """
+
+    def _import(self):
+        from medic_plus.api import daystar_health
+        return daystar_health
+
+    def test_rejects_user_with_no_practice(self):
+        """No Practice Member → no patient detail. The SPA translates the
+        PermissionError into the no-practice error card; we never even
+        attempt the cross-tenant patient lookup."""
+        m = self._import()
+        with patch("medic_plus.api.daystar_health.get_active_practice",
+                   side_effect=frappe.PermissionError("no practice")):
+            with self.assertRaises(frappe.PermissionError):
+                m.get_patient_detail(patient="PAT-00001")
+
+    def test_rejects_cross_tenant_patient_request(self):
+        """A user signed into Practice A who requests a Patient that belongs
+        to Practice B gets PermissionError — never the patient's data, never
+        even a 'not found' that would confirm the patient exists. Distinct
+        error from 'patient not found' so the caller can't probe Practice
+        membership of arbitrary IDs."""
+        m = self._import()
+        with patch("medic_plus.api.daystar_health.get_active_practice",
+                   return_value="PRAC-00001"), \
+             patch("medic_plus.api.daystar_health.frappe.db.get_value",
+                   return_value="PRAC-00002"):  # patient belongs elsewhere
+            with self.assertRaises(frappe.PermissionError):
+                m.get_patient_detail(patient="PAT-FROM-OTHER-PRACTICE")
+
+
 class TestPatientPermissionQueryForDoctor(unittest.TestCase):
     """Behavior tests for the Patient PQC the Daystar Health patients-list
     screen relies on. The screen calls the REST resource API for Patient,
@@ -297,3 +334,73 @@ class TestPatientPermissionQueryForDoctor(unittest.TestCase):
              patch("medic_plus.api.permissions._get_user_practice", return_value=None):
             condition = m.get_patient_permission_query(user="orphan@example.test")
         self.assertEqual(condition, "1=0")
+
+
+class TestPatientSummaryFormatHelper(unittest.TestCase):
+    """Behavior tests for patient_summary._format_patient_summary.
+
+    The helper is a pure transformation: it accepts already-fetched rows and
+    returns the patient detail composite payload. POPIA exclusion and per-tab
+    caps are enforced here, so they're testable in isolation without DB or
+    auth context.
+    """
+
+    def _import(self):
+        from medic_plus.api import patient_summary
+        return patient_summary
+
+    def test_strips_custom_sa_id_number_from_patient_block(self):
+        """The composite must never expose POPIA-protected fields. Even if
+        the caller hands the helper a Patient row containing custom_sa_id_number,
+        the field is stripped before serialisation. The detail screen has no
+        unmask flow this iteration; the SA ID is simply unreachable."""
+        m = self._import()
+        patient_row = {
+            "name": "PAT-00001",
+            "patient_name": "Eleanor Chen",
+            "dob": "1964-03-14",
+            "sex": "Female",
+            "mobile": "+27821234567",
+            "email": "e.chen@example.test",
+            "custom_sa_id_number": "6403140001088",
+            "custom_practice": "PRAC-00001",
+        }
+        payload = m._format_patient_summary(
+            patient_row=patient_row,
+            visits=[], vitals=[], medications=[], labs=[], notes=[],
+        )
+        import json
+        serialised = json.dumps(payload, default=str)
+        self.assertNotIn("6403140001088", serialised,
+                         "POPIA: SA ID value must never appear anywhere in the payload")
+        self.assertNotIn("custom_sa_id_number", serialised,
+                         "POPIA: the field key itself must not leak (would advertise a maskable field)")
+
+    def test_per_tab_caps_enforced(self):
+        """Each tab is capped at the design's load limit. Visits / Labs /
+        Medications / Notes cap at 20; Vitals caps at 12 (the trend chart
+        renders exactly 12 data points). Caps are enforced even when the
+        caller hands in more rows — guards against future query tweaks
+        accidentally bloating the payload."""
+        m = self._import()
+        # 30 of each — well over the caps.
+        oversize = lambda kind: [{"id": f"{kind}-{i:03d}"} for i in range(30)]
+        payload = m._format_patient_summary(
+            patient_row={"name": "PAT-1"},
+            visits=oversize("V"),
+            vitals=oversize("VS"),
+            medications=oversize("M"),
+            labs=oversize("L"),
+            notes=oversize("N"),
+        )
+        self.assertEqual(len(payload["visits"]), 20, "Visits cap must be 20")
+        self.assertEqual(len(payload["vitals"]), 12, "Vitals cap must be 12 (trend chart length)")
+        self.assertEqual(len(payload["medications"]), 20, "Medications cap must be 20")
+        self.assertEqual(len(payload["labs"]), 20, "Labs cap must be 20")
+        self.assertEqual(len(payload["notes"]), 20, "Notes cap must be 20")
+        # The first 20 (or 12 for vitals) are preserved in order — caller is
+        # responsible for ordering, helper doesn't reshuffle.
+        self.assertEqual(payload["visits"][0]["id"], "V-000")
+        self.assertEqual(payload["visits"][19]["id"], "V-019")
+        self.assertEqual(payload["vitals"][0]["id"], "VS-000")
+        self.assertEqual(payload["vitals"][11]["id"], "VS-011")

--- a/medic_plus/public/daystar-health/meridian-patient.jsx
+++ b/medic_plus/public/daystar-health/meridian-patient.jsx
@@ -1,292 +1,313 @@
-// Patient detail
-function MPatientScreen({ go, patientId }) {
-  const p = window.MH_DATA.PATIENTS.find(x => x.id === patientId) || window.MH_DATA.PATIENTS[0];
-  const [tab, setTab] = mUseState('overview');
-  const visits = window.MH_DATA.VISITS_FOR(p.id);
-  const labs = window.MH_DATA.LABS_FOR(p.id);
-  const meds = window.MH_DATA.MEDS_FOR(p.id);
-  const notes = window.MH_DATA.NOTES_FOR(p.id);
-  const trend = window.MH_DATA.VITALS_TREND_FOR(p.id);
+// Patient detail — wired to medic_plus.api.daystar_health.get_patient_detail.
+// One composite fetch, six tabs hydrate from the bundle. POPIA: SA ID is
+// never returned by the endpoint, so it cannot leak into the UI here.
 
-  const tabs = [
-    { id: 'overview', label: 'Overview' },
-    { id: 'visits', label: 'Visits', count: visits.length },
-    { id: 'vitals', label: 'Vitals' },
-    { id: 'medications', label: 'Medications', count: meds.length },
-    { id: 'labs', label: 'Labs', count: labs.length },
-    { id: 'notes', label: 'Notes', count: notes.length },
-  ];
+const PATIENT_TABS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'visits', label: 'Visits' },
+  { id: 'vitals', label: 'Vitals' },
+  { id: 'medications', label: 'Medications' },
+  { id: 'labs', label: 'Labs' },
+  { id: 'notes', label: 'Notes' },
+];
+
+function MPatientScreen({ go, patientId }) {
+  const [tab, setTab] = mUseState('overview');
+  const [state, setState] = mUseState({ status: 'loading', data: null, error: null });
+
+  mUseEffect(() => {
+    let cancelled = false;
+    setState({ status: 'loading', data: null, error: null });
+    window.meridianApi
+      .call('medic_plus.api.daystar_health.get_patient_detail', { patient: patientId })
+      .then(data => { if (!cancelled) setState({ status: 'ready', data, error: null }); })
+      .catch(err => {
+        if (cancelled) return;
+        const msg = err.message || 'Could not load patient.';
+        setState({ status: 'error', data: null, error: msg });
+        window.meridianApi.showError(msg);
+      });
+    return () => { cancelled = true; };
+  }, [patientId]);
+
+  if (state.status === 'loading') return <PatientSkeleton />;
+  if (state.status === 'error') return <PatientError message={state.error} go={go} />;
+
+  const data = state.data;
+  const p = data.patient || {};
+  const links = data.full_record_links || {};
 
   return (
-    <div className="page fade-in">
-      {/* Header */}
-      <div style={{ display: 'flex', gap: 18, alignItems: 'flex-start', marginBottom: 20 }}>
-        <div className="avatar" style={{ width: 64, height: 64, fontSize: 22, borderRadius: 16 }}>
-          {p.name.split(' ').map(n => n[0]).join('')}
+    <div className="page fade-in" data-testid="patient-detail-page">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 16 }}>
+        <div className="avatar" style={{ width: 56, height: 56, fontSize: 18, borderRadius: 14 }}>
+          {(p.patient_name || p.name || '?').split(' ').map(n => n[0]).join('').slice(0, 2)}
         </div>
-        <div style={{ flex: 1 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
-            <h1 style={{ fontSize: 22, fontWeight: 600, margin: 0, letterSpacing: '-0.02em' }}>{p.name}</h1>
-            <span className={`badge ${p.status === 'Stable' ? 'badge-success' : p.status === 'Watch' ? 'badge-warn' : 'badge-danger'}`}>{p.status}</span>
-            <span className={`badge ${p.risk === 'High' ? 'badge-danger' : p.risk === 'Moderate' ? 'badge-warn' : 'badge-neutral'}`}>{p.risk} risk</span>
-            {p.allergies.length > 0 && <span className="badge badge-danger" style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><window.MIcons.AlertTriangle size={11} /> Allergy alert</span>}
-          </div>
-          <div style={{ display: 'flex', gap: 18, fontSize: 12.5, color: 'var(--text-muted)', flexWrap: 'wrap' }}>
-            <span><span className="mono">{p.mrn}</span></span>
-            <span>{p.age} yrs · {p.sex}</span>
-            <span>DOB {p.dob}</span>
-            <span>{p.insurance}</span>
-            <span>PCP: {p.primary}</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h1 data-testid="patient-name" style={{ fontSize: 22, fontWeight: 600, margin: 0, letterSpacing: '-0.02em' }}>
+            {p.patient_name || p.name}
+          </h1>
+          <div style={{ fontSize: 12.5, color: 'var(--text-muted)', marginTop: 4 }}>
+            {[p.sex, p.dob ? `DOB ${p.dob}` : null, p.email, p.mobile].filter(Boolean).join(' · ') || '—'}
           </div>
         </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button className="btn btn-secondary btn-sm"><window.MIcons.Mail size={14} /> Message</button>
-          <button className="btn btn-secondary btn-sm"><window.MIcons.Calendar size={14} /> Schedule</button>
-          <button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> Start visit</button>
-        </div>
+        <span className={`badge ${p.status === 'Active' ? 'badge-success' : 'badge-neutral'}`}>{p.status || '—'}</span>
       </div>
 
-      {/* Tabs */}
-      <div className="tabs" style={{ marginBottom: 'var(--gap)' }}>
-        {tabs.map(t => (
-          <button key={t.id} className={`tab ${tab === t.id ? 'active' : ''}`} onClick={() => setTab(t.id)}>
-            {t.label}{t.count != null && <span style={{ fontSize: 11, color: 'var(--text-dim)', marginLeft: 6 }}>{t.count}</span>}
+      <div className="tabs" data-testid="patient-tabs" style={{ display: 'flex', gap: 4, borderBottom: '1px solid var(--border)', marginBottom: 16 }}>
+        {PATIENT_TABS.map(t => (
+          <button
+            key={t.id}
+            data-testid={`patient-tab-${t.id}`}
+            className={`tab ${tab === t.id ? 'active' : ''}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
           </button>
         ))}
       </div>
 
-      {tab === 'overview' && (
-        <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: 'var(--gap)' }}>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
-            {/* Vitals snapshot */}
-            <div className="card card-pad">
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 14 }}>
-                <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: 0 }}>Latest vitals</h3>
-                <span style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>Recorded Apr 21, 2026</span>
-              </div>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 14 }}>
-                {[
-                  { label: 'BP', value: p.vitals.bp, unit: 'mmHg', tone: p.vitals.bp.split('/')[0] > 130 ? 'warn' : 'ok' },
-                  { label: 'HR', value: p.vitals.hr, unit: 'bpm', tone: 'ok' },
-                  { label: 'SpO₂', value: p.vitals.spo2, unit: '%', tone: p.vitals.spo2 < 95 ? 'warn' : 'ok' },
-                  { label: 'Weight', value: p.vitals.weight, unit: '', tone: 'ok' },
-                  { label: 'BMI', value: p.vitals.bmi, unit: '', tone: p.vitals.bmi > 25 ? 'warn' : 'ok' },
-                ].map((v, i) => (
-                  <div key={i} style={{ paddingLeft: i > 0 ? 14 : 0, borderLeft: i > 0 ? '1px solid var(--border)' : 'none' }}>
-                    <div style={{ fontSize: 11, color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>{v.label}</div>
-                    <div style={{ fontSize: 22, fontWeight: 600, fontFamily: 'var(--font-mono)', letterSpacing: '-0.02em', color: v.tone === 'warn' ? '#b45309' : 'var(--text)' }}>{v.value}</div>
-                    <div style={{ fontSize: 10.5, color: 'var(--text-dim)' }}>{v.unit}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
+      {tab === 'overview' && <OverviewTab data={data} />}
+      {tab === 'visits' && <VisitsTab visits={data.visits || []} link={links.visits} />}
+      {tab === 'vitals' && <VitalsTab vitals={data.vitals || []} link={links.vitals} />}
+      {tab === 'medications' && <MedicationsTab meds={data.medications || []} link={links.medications} />}
+      {tab === 'labs' && <LabsTab labs={data.labs || []} link={links.labs} />}
+      {tab === 'notes' && <NotesTab notes={data.notes || []} link={links.notes} />}
+    </div>
+  );
+}
 
-            {/* BP trend */}
-            <div className="card card-pad">
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 12 }}>
-                <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: 0 }}>Blood pressure — last 12 visits</h3>
-                <div style={{ display: 'flex', gap: 12, fontSize: 11.5 }}>
-                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><span style={{ width: 8, height: 8, borderRadius: 2, background: '#2563eb' }} />Systolic</span>
-                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}><span style={{ width: 8, height: 8, borderRadius: 2, background: '#94a3b8' }} />Diastolic</span>
-                </div>
-              </div>
-              <svg viewBox="0 0 480 160" style={{ width: '100%', height: 160 }}>
-                {/* gridlines */}
-                {[40, 60, 80, 100, 120].map((y, i) => (
-                  <g key={i}>
-                    <line x1="40" x2="470" y1={y} y2={y} stroke="var(--border)" strokeDasharray="2 3" />
-                    <text x="32" y={y + 3} textAnchor="end" fontSize="9" fill="var(--text-dim)" fontFamily="var(--font-mono)">{160 - y}</text>
-                  </g>
-                ))}
-                {/* target band */}
-                <rect x="40" y={160 - 130} width="430" height="20" fill="#10b981" opacity="0.08" />
-                {/* lines */}
-                {(() => {
-                  const sx = (i) => 40 + i * (430 / 11);
-                  const sy = (v) => 160 - v;
-                  const path = (arr) => arr.map((v, i) => `${i === 0 ? 'M' : 'L'} ${sx(i)} ${sy(v)}`).join(' ');
-                  return (
-                    <>
-                      <path d={path(trend.bp_sys)} fill="none" stroke="#2563eb" strokeWidth="2" />
-                      <path d={path(trend.bp_dia)} fill="none" stroke="#94a3b8" strokeWidth="2" />
-                      {trend.bp_sys.map((v, i) => <circle key={'s'+i} cx={sx(i)} cy={sy(v)} r="2.5" fill="#2563eb" />)}
-                      {trend.bp_dia.map((v, i) => <circle key={'d'+i} cx={sx(i)} cy={sy(v)} r="2.5" fill="#94a3b8" />)}
-                    </>
-                  );
-                })()}
-              </svg>
-            </div>
-
-            {/* Recent visits */}
-            <div className="card">
-              <div className="card-header"><h3 className="card-title">Recent visits</h3><button className="btn btn-ghost btn-sm" onClick={() => setTab('visits')}>All visits</button></div>
-              <div>
-                {visits.slice(0, 3).map((v, i) => (
-                  <div key={i} style={{ padding: '14px 20px', borderBottom: i < 2 ? '1px solid var(--border)' : 'none' }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
-                      <div style={{ fontSize: 13.5, fontWeight: 500 }}>{v.reason}</div>
-                      <div className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{v.date}</div>
-                    </div>
-                    <div style={{ fontSize: 11.5, color: 'var(--text-dim)', marginBottom: 6 }}>{v.type} · {v.provider}</div>
-                    <div style={{ fontSize: 12.5, color: 'var(--text-muted)' }}>{v.notes}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
-            {/* Contact */}
-            <div className="card card-pad">
-              <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 12px' }}>Contact</h3>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 10, fontSize: 12.5 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Phone</span><span className="mono">{p.phone}</span></div>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Email</span><span>{p.email}</span></div>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Insurance</span><span>{p.insurance}</span></div>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Last seen</span><span className="mono">{p.lastSeen}</span></div>
-                <div style={{ display: 'flex', justifyContent: 'space-between' }}><span style={{ color: 'var(--text-dim)' }}>Next appt</span><span className="mono" style={{ color: 'var(--accent-text)', fontWeight: 500 }}>{p.nextAppt}</span></div>
-              </div>
-            </div>
-
-            {/* Conditions */}
-            <div className="card card-pad">
-              <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 10px' }}>Active conditions</h3>
-              {p.conditions.length === 0 ? (
-                <div style={{ fontSize: 12.5, color: 'var(--text-dim)' }}>None on file.</div>
-              ) : (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                  {p.conditions.map((c, i) => (
-                    <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', background: 'var(--bg-subtle)', border: '1px solid var(--border)', borderRadius: 6, fontSize: 12.5 }}>
-                      <window.MIcons.Heart size={13} stroke="var(--accent)" />
-                      <span style={{ flex: 1 }}>{c}</span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Allergies */}
-            <div className="card card-pad">
-              <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 10px' }}>Allergies</h3>
-              {p.allergies.length === 0 ? (
-                <div style={{ fontSize: 12.5, color: 'var(--text-dim)' }}>NKDA — No known drug allergies.</div>
-              ) : (
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                  {p.allergies.map((a, i) => (
-                    <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', background: 'var(--danger-soft)', borderRadius: 6, fontSize: 12.5, color: '#b91c1c' }}>
-                      <window.MIcons.AlertTriangle size={13} />
-                      <span style={{ flex: 1, fontWeight: 500 }}>{a}</span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
+function PatientSkeleton() {
+  return (
+    <div className="page fade-in" data-testid="patient-skeleton">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 16 }}>
+        <div style={{ width: 56, height: 56, borderRadius: 14, background: 'var(--bg-subtle)', animation: 'pulse 1.6s infinite' }} />
+        <div style={{ flex: 1 }}>
+          <PSkeletonBar w={220} h={20} />
+          <div style={{ height: 8 }} />
+          <PSkeletonBar w={300} h={14} />
         </div>
-      )}
+      </div>
+      <div className="card card-pad"><PSkeletonBar w="100%" h={140} /></div>
+    </div>
+  );
+}
 
-      {tab === 'visits' && (
-        <div className="card">
-          <div className="card-header"><h3 className="card-title">Visit history</h3><button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> New visit</button></div>
-          <div>
-            {visits.map((v, i) => (
-              <div key={i} style={{ padding: '16px 20px', borderBottom: i < visits.length - 1 ? '1px solid var(--border)' : 'none' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
-                  <div>
-                    <span style={{ fontSize: 14, fontWeight: 500 }}>{v.reason}</span>
-                    <span className="badge badge-neutral" style={{ marginLeft: 8 }}>{v.type}</span>
-                  </div>
-                  <div className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{v.date} · {v.provider}</div>
-                </div>
-                <div style={{ fontSize: 13, color: 'var(--text-muted)' }}>{v.notes}</div>
-              </div>
+function PSkeletonBar({ w = '100%', h = 14 }) {
+  return <div style={{ width: w, height: h, background: 'var(--bg-subtle)', borderRadius: 4, animation: 'pulse 1.6s infinite' }} />;
+}
+
+function PatientError({ message, go }) {
+  return (
+    <div className="page fade-in">
+      <div className="card card-pad" data-testid="patient-error" style={{ textAlign: 'center', padding: 60 }}>
+        <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 8px' }}>Couldn't load patient</h2>
+        <p style={{ fontSize: 13, color: 'var(--text-muted)', marginBottom: 16 }}>{message}</p>
+        <button className="btn btn-secondary btn-sm" onClick={() => go('patients')}>Back to patients</button>
+      </div>
+    </div>
+  );
+}
+
+function OverviewTab({ data }) {
+  const p = data.patient || {};
+  const latestVitals = (data.vitals || [])[0];
+  return (
+    <div data-testid="patient-tab-content-overview" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--gap)' }}>
+      <div className="card card-pad">
+        <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 12px' }}>Demographics</h3>
+        <KV label="Name" value={p.patient_name || p.name} />
+        <KV label="Sex" value={p.sex} />
+        <KV label="Date of birth" value={p.dob} />
+        <KV label="Email" value={p.email} />
+        <KV label="Mobile" value={p.mobile} />
+      </div>
+      <div className="card card-pad">
+        <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 12px' }}>Latest vitals</h3>
+        {latestVitals ? (
+          <>
+            <KV label="Date" value={latestVitals.date} />
+            <KV label="BP" value={latestVitals.bp_systolic && latestVitals.bp_diastolic ? `${latestVitals.bp_systolic}/${latestVitals.bp_diastolic}` : null} />
+            <KV label="Weight" value={latestVitals.weight} />
+            <KV label="Temperature" value={latestVitals.temperature} />
+          </>
+        ) : (
+          <div style={{ fontSize: 13, color: 'var(--text-muted)' }}>No vitals recorded yet.</div>
+        )}
+      </div>
+      <div className="card card-pad" style={{ gridColumn: '1 / -1' }}>
+        <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 12px' }}>Activity at a glance</h3>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 16 }}>
+          <Stat label="Visits" value={(data.visits || []).length} />
+          <Stat label="Active medications" value={(data.medications || []).length} />
+          <Stat label="Lab tests" value={(data.labs || []).length} />
+          <Stat label="Notes" value={(data.notes || []).length} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function KV({ label, value }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', padding: '6px 0', borderBottom: '1px solid var(--border)', fontSize: 13 }}>
+      <span style={{ color: 'var(--text-muted)' }}>{label}</span>
+      <span style={{ fontWeight: 500 }}>{value || '—'}</span>
+    </div>
+  );
+}
+
+function Stat({ label, value }) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>{label}</div>
+      <div style={{ fontSize: 22, fontWeight: 600, marginTop: 4 }}>{value}</div>
+    </div>
+  );
+}
+
+function VisitsTab({ visits, link }) {
+  return (
+    <div className="card" data-testid="patient-tab-content-visits">
+      <div className="card-header">
+        <h3 className="card-title">Recent visits ({visits.length})</h3>
+        {link && <a href={link} target="_blank" rel="noreferrer" className="btn btn-ghost btn-sm" data-testid="patient-tab-link-visits">See full record →</a>}
+      </div>
+      {visits.length === 0 ? (
+        <EmptyTab name="visits" />
+      ) : (
+        <table className="table">
+          <thead><tr><th>Date</th><th>Type</th><th>Practitioner</th><th>Department</th></tr></thead>
+          <tbody>
+            {visits.map(v => (
+              <tr key={v.id}>
+                <td className="mono">{v.date || '—'}</td>
+                <td>{v.type || '—'}</td>
+                <td>{v.practitioner || '—'}</td>
+                <td>{v.department || '—'}</td>
+              </tr>
             ))}
-          </div>
-        </div>
+          </tbody>
+        </table>
       )}
+    </div>
+  );
+}
 
-      {tab === 'vitals' && (
-        <div className="card card-pad">
-          <h3 style={{ fontSize: 13.5, fontWeight: 600, margin: '0 0 14px' }}>Vitals trends</h3>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--gap)' }}>
-            {[
-              { label: 'Heart rate (bpm)', data: trend.hr, color: '#ef4444' },
-              { label: 'Weight (lb)', data: trend.weight, color: '#8b5cf6' },
-            ].map((s, i) => (
-              <div key={i} className="card card-pad">
-                <h4 style={{ fontSize: 12.5, fontWeight: 500, margin: '0 0 10px', color: 'var(--text-muted)' }}>{s.label}</h4>
-                <window.Sparkline data={s.data} color={s.color} height={80} />
-              </div>
+function VitalsTab({ vitals, link }) {
+  return (
+    <div className="card" data-testid="patient-tab-content-vitals">
+      <div className="card-header">
+        <h3 className="card-title">Latest vitals ({vitals.length})</h3>
+        {link && <a href={link} target="_blank" rel="noreferrer" className="btn btn-ghost btn-sm" data-testid="patient-tab-link-vitals">See full record →</a>}
+      </div>
+      {vitals.length === 0 ? (
+        <EmptyTab name="vital signs" />
+      ) : (
+        <table className="table">
+          <thead><tr><th>Date</th><th>BP</th><th>Weight</th><th>Temperature</th><th>Resp.</th></tr></thead>
+          <tbody>
+            {vitals.map(v => (
+              <tr key={v.id}>
+                <td className="mono">{v.date || '—'}</td>
+                <td>{v.bp_systolic && v.bp_diastolic ? `${v.bp_systolic}/${v.bp_diastolic}` : '—'}</td>
+                <td>{v.weight || '—'}</td>
+                <td>{v.temperature || '—'}</td>
+                <td>{v.respiratory_rate || '—'}</td>
+              </tr>
             ))}
-          </div>
-        </div>
+          </tbody>
+        </table>
       )}
+    </div>
+  );
+}
 
-      {tab === 'medications' && (
-        <div className="card">
-          <div className="card-header"><h3 className="card-title">Active medications</h3><button className="btn btn-primary btn-sm"><window.MIcons.Plus size={14} /> Prescribe</button></div>
-          <table className="table">
-            <thead><tr><th>Medication</th><th>Dose</th><th>Frequency</th><th>Class</th><th>Started</th><th>Refills</th><th>Status</th></tr></thead>
-            <tbody>
-              {meds.map((m, i) => (
-                <tr key={i}>
-                  <td><div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><window.MIcons.Pill size={14} stroke="var(--accent)" /><span style={{ fontWeight: 500 }}>{m.name}</span></div></td>
-                  <td className="mono">{m.dose}</td>
-                  <td style={{ fontSize: 12.5 }}>{m.freq}</td>
-                  <td style={{ color: 'var(--text-muted)', fontSize: 12.5 }}>{m.class}</td>
-                  <td className="mono" style={{ fontSize: 12 }}>{m.start}</td>
-                  <td className="mono">{m.refills}</td>
-                  <td><span className="badge badge-success">{m.status}</span></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+function MedicationsTab({ meds, link }) {
+  return (
+    <div className="card" data-testid="patient-tab-content-medications">
+      <div className="card-header">
+        <h3 className="card-title">Active medications ({meds.length})</h3>
+        {link && <a href={link} target="_blank" rel="noreferrer" className="btn btn-ghost btn-sm" data-testid="patient-tab-link-medications">See full record →</a>}
+      </div>
+      {meds.length === 0 ? (
+        <EmptyTab name="medications" />
+      ) : (
+        <table className="table">
+          <thead><tr><th>Drug</th><th>Dosage</th><th>Period</th><th>Started</th></tr></thead>
+          <tbody>
+            {meds.map(m => (
+              <tr key={m.id}>
+                <td style={{ fontWeight: 500 }}>{m.name || '—'}</td>
+                <td>{m.dosage || '—'}</td>
+                <td>{m.period || '—'}</td>
+                <td className="mono">{m.started || '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
+    </div>
+  );
+}
 
-      {tab === 'labs' && (
-        <div className="card">
-          <div className="card-header"><h3 className="card-title">Lab results — Apr 21, 2026</h3><button className="btn btn-secondary btn-sm"><window.MIcons.Download size={14} /> Export PDF</button></div>
-          <table className="table">
-            <thead><tr><th>Test</th><th style={{ textAlign: 'right' }}>Value</th><th>Unit</th><th>Reference</th><th>Status</th></tr></thead>
-            <tbody>
-              {labs.map((l, i) => (
-                <tr key={i}>
-                  <td style={{ fontWeight: 500 }}>{l.name}</td>
-                  <td className="mono" style={{ textAlign: 'right', fontWeight: 600, color: l.status === 'High' ? '#b45309' : l.status === 'Low' ? '#1d4ed8' : 'var(--text)' }}>{l.value}</td>
-                  <td style={{ fontSize: 12.5, color: 'var(--text-muted)' }}>{l.unit}</td>
-                  <td className="mono" style={{ fontSize: 12, color: 'var(--text-muted)' }}>{l.range}</td>
-                  <td><span className={`badge ${l.status === 'Normal' ? 'badge-success' : l.status === 'High' ? 'badge-warn' : 'badge-info'}`}>{l.status}</span></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+function LabsTab({ labs, link }) {
+  return (
+    <div className="card" data-testid="patient-tab-content-labs">
+      <div className="card-header">
+        <h3 className="card-title">Lab tests ({labs.length})</h3>
+        {link && <a href={link} target="_blank" rel="noreferrer" className="btn btn-ghost btn-sm" data-testid="patient-tab-link-labs">See full record →</a>}
+      </div>
+      {labs.length === 0 ? (
+        <EmptyTab name="lab tests" />
+      ) : (
+        <table className="table">
+          <thead><tr><th>Test</th><th>Status</th><th>Result date</th></tr></thead>
+          <tbody>
+            {labs.map(l => (
+              <tr key={l.id}>
+                <td>{l.template || l.id}</td>
+                <td><span className="badge badge-neutral">{l.status || '—'}</span></td>
+                <td className="mono">{l.result_date || '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
+    </div>
+  );
+}
 
-      {tab === 'notes' && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
-          <div className="card card-pad">
-            <textarea className="textarea" rows="3" placeholder="Add a clinical note…" style={{ marginBottom: 10 }} />
-            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
-              <button className="btn btn-secondary btn-sm">Save draft</button>
-              <button className="btn btn-primary btn-sm">Sign & save</button>
-            </div>
-          </div>
+function NotesTab({ notes, link }) {
+  return (
+    <div className="card" data-testid="patient-tab-content-notes">
+      <div className="card-header">
+        <h3 className="card-title">Notes ({notes.length})</h3>
+        {link && <a href={link} target="_blank" rel="noreferrer" className="btn btn-ghost btn-sm" data-testid="patient-tab-link-notes">See full record →</a>}
+      </div>
+      {notes.length === 0 ? (
+        <EmptyTab name="notes" />
+      ) : (
+        <div>
           {notes.map((n, i) => (
-            <div key={i} className="card card-pad">
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <div className="avatar avatar-sm" style={{ width: 26, height: 26, fontSize: 10 }}>{n.author.split(' ').map(s => s[0]).join('').slice(0, 2)}</div>
-                  <span style={{ fontSize: 13, fontWeight: 500 }}>{n.author}</span>
-                </div>
-                <span className="mono" style={{ fontSize: 11.5, color: 'var(--text-dim)' }}>{n.when}</span>
+            <div key={n.id} style={{ padding: '14px 20px', borderBottom: i < notes.length - 1 ? '1px solid var(--border)' : 'none' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6, fontSize: 12 }}>
+                <span style={{ fontWeight: 500 }}>{n.author || '—'}</span>
+                <span style={{ color: 'var(--text-dim)' }}>{n.when || ''}</span>
               </div>
-              <div style={{ fontSize: 13, color: 'var(--text-muted)', lineHeight: 1.55 }}>{n.body}</div>
+              <div style={{ fontSize: 13, color: 'var(--text-muted)' }} dangerouslySetInnerHTML={{ __html: n.body || '' }} />
             </div>
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function EmptyTab({ name }) {
+  return (
+    <div data-testid="patient-tab-empty" style={{ padding: 40, textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+      No {name} recorded for this patient yet.
     </div>
   );
 }

--- a/medic_plus/tests/ui/test_daystar_health.py
+++ b/medic_plus/tests/ui/test_daystar_health.py
@@ -328,3 +328,73 @@ class TestPatientsListEmptyState:
         expect(page.locator('[data-testid="patients-empty-state"]')).to_be_visible(timeout=10_000)
         # No rows are visible.
         assert page.locator('[data-testid="patients-row"]').count() == 0
+
+
+# ── slice 4: patient detail ──────────────────────────────────────────────────
+
+
+class TestPatientDetailRender:
+    """Clicking a patient from the list navigates to the detail screen, which
+    fetches the composite endpoint once and hydrates all six tabs from the
+    bundle — no waterfall on tab switch."""
+
+    def test_detail_loads_all_tabs_render(self, admin_with_practice_membership, page: Page):
+        _login_as_admin(page)
+        _open_patients_screen(page)
+
+        # Administrator's view bypasses Patient PQC (Healthcare Administrator
+        # role). The list shows all 133 patients across every Practice, but
+        # get_patient_detail correctly rejects cross-tenant clicks. Search for
+        # a known PRAC-00001 patient prefix so we click a row in our Practice.
+        page.locator('[data-testid="patients-search"]').fill("Booking")
+        page.wait_for_timeout(800)
+        first_row = page.locator('[data-testid="patients-row"]').first
+        expect(first_row).to_be_visible(timeout=15_000)
+        first_row.click()
+
+        # Detail page renders.
+        expect(page.locator('[data-testid="patient-detail-page"]')).to_be_visible(timeout=15_000)
+        expect(page.locator('[data-testid="patient-name"]')).to_be_visible()
+
+        # All 6 tab buttons exist.
+        for tab_id in ("overview", "visits", "vitals", "medications", "labs", "notes"):
+            expect(page.locator(f'[data-testid="patient-tab-{tab_id}"]')).to_be_visible()
+
+        # Overview is the default — its content container is visible.
+        expect(page.locator('[data-testid="patient-tab-content-overview"]')).to_be_visible()
+
+        # Switch to each remaining tab and confirm its content container shows.
+        for tab_id in ("visits", "vitals", "medications", "labs", "notes"):
+            page.locator(f'[data-testid="patient-tab-{tab_id}"]').click()
+            expect(page.locator(f'[data-testid="patient-tab-content-{tab_id}"]')).to_be_visible(timeout=5_000)
+
+    def test_detail_payload_does_not_leak_custom_sa_id_number(self, admin_with_practice_membership, page: Page):
+        """POPIA contract: the detail screen's payload must never contain the
+        SA ID number. We grab the network response of the composite call and
+        assert the field is absent from the JSON."""
+        _login_as_admin(page)
+        _open_patients_screen(page)
+
+        captured = {}
+
+        def on_response(response):
+            url = response.url
+            if "get_patient_detail" in url and response.status == 200:
+                try:
+                    captured["body"] = response.text()
+                except Exception:
+                    pass
+
+        page.on("response", on_response)
+
+        page.locator('[data-testid="patients-search"]').fill("Booking")
+        page.wait_for_timeout(800)
+        first_row = page.locator('[data-testid="patients-row"]').first
+        expect(first_row).to_be_visible(timeout=15_000)
+        first_row.click()
+        expect(page.locator('[data-testid="patient-detail-page"]')).to_be_visible(timeout=15_000)
+
+        body = captured.get("body", "")
+        assert "custom_sa_id_number" not in body, (
+            "POPIA: the get_patient_detail response leaked custom_sa_id_number"
+        )

--- a/techspec.md
+++ b/techspec.md
@@ -4,6 +4,37 @@ Living technical specification. Every feature, bugfix, refactor, and design deci
 
 ---
 
+## 2026-04-29 — Phase 1I (Issue #7): Daystar Health patient detail — wired to composite endpoint
+
+### Scope
+Slice 4 of 5 wiring `/daystar-health`. Replaces the static `MH_DATA` lookups on the patient detail screen with a single composite endpoint that returns all six tabs in one round trip.
+
+### Deep module: `patient_summary`
+- `build_patient_summary(patient_name, practice)` — orchestrator. Fetches Patient + Patient Encounters (last 20) + Vital Signs (last 12) + active medications de-duped across encounters + Lab Tests (last 20) + Frappe Comments on the Patient (last 20). Hands them to the format helper.
+- `_format_patient_summary(...)` — pure transformation. Caps each tab and applies the **POPIA whitelist**: only the fields in `_PATIENT_PUBLIC_FIELDS` (`name / patient_name / dob / sex / mobile / email / status`) survive into the patient block. `custom_sa_id_number` is impossible to leak — it never appears in the response, even if the caller hands the helper a row containing it.
+
+### Endpoint: `daystar_health.get_patient_detail(patient)`
+- Cross-tenant guard: looks up the patient's `custom_practice` and refuses with `frappe.PermissionError` if it doesn't match the caller's active Practice. Same error class as no-practice, so an attacker can't probe Practice membership of arbitrary IDs by looking at the response code.
+- Returns the composite payload from `build_patient_summary`.
+- "See full record" links per tab go to the Frappe Desk filtered list — built into the payload as `full_record_links`.
+
+### Frontend rewire (`meridian-patient.jsx`)
+- Three render states: skeleton, error (with "Back to patients" CTA), ready.
+- Ready state has six tabs: Overview / Visits / Vitals / Medications / Labs / Notes — all hydrated from the same fetch, no waterfall on tab switch.
+- Notes tab renders Comment HTML via `dangerouslySetInnerHTML` (Frappe's HTML Editor field — same trust boundary as the Frappe Desk activity feed).
+
+### Tests
+- Python: 4 new unit tests — POPIA exclusion (the tracer), per-tab caps (visits/labs/meds/notes capped at 20, vitals at 12), endpoint rejects no-practice, endpoint rejects cross-tenant patient request.
+- Playwright: 2 new tests — detail screen renders all 6 tab containers (with search filter to ensure we click a row in our own Practice when admin's view bypasses Patient PQC); response body of the composite call asserted to never contain `custom_sa_id_number`.
+
+### Out of scope (later slices)
+- Profile + password change (#8) — last slice.
+
+### Surfaced gap (Issue #12)
+While testing as a real Practice user (selfserve.test), discovered that medic_plus ships no Custom DocPerm fixtures granting Practice Admin / Practice Doctor / Practice Receptionist roles read access on Patient and related Healthcare doctypes. Practice users get 403 from `/api/resource/Patient` *before* the PQC runs because the role-permission gate isn't open. Tracked in #12 with a workaround (Physician role added to test user).
+
+---
+
 ## 2026-04-29 — Phase 1H (Issue #6): Daystar Health patients list — wired to REST resource API
 
 ### Scope


### PR DESCRIPTION
Closes #7. Slice 4 of 5 wiring `/daystar-health`. Replaces static `MH_DATA` lookups on the patient detail screen with one composite endpoint that returns all six tabs in one round trip.

## Summary

- **Deep module** `api/patient_summary` — `build_patient_summary(patient_name, practice)` orchestrator + a pure `_format_patient_summary(...)` helper for testable shaping rules (per-tab caps, POPIA whitelisting).
- **Endpoint** `medic_plus.api.daystar_health.get_patient_detail(patient)` — cross-tenant guard via Patient.custom_practice lookup; returns the composite. Same `PermissionError` for no-practice and cross-tenant so the response cannot be used to probe Practice membership.
- **POPIA**: only `name / patient_name / dob / sex / mobile / email / status` survive into the patient block. `custom_sa_id_number` cannot leak even if the caller hands the helper a row containing it.
- **Frontend rewrite** — three render states (skeleton / error / ready); ready state has six tabs all hydrated from one fetch. "See full record →" link per tab points at the Frappe Desk filtered list.

## Per the design decisions

Per-tab caps from Q10: visits / labs / medications / notes capped at 20; vitals at 12 (matches the trend chart length). Notes come from the Frappe `Comment` doctype on Patient (Q10 sub-decision b-1). No SA ID unmask flow this iteration (Q7).

## Test plan

- [x] `env/bin/python -m pytest apps/medic_plus/medic_plus/api/test_daystar_health.py -v` — 15 passed (4 new: POPIA, per-tab caps, no-practice rejection, cross-tenant rejection)
- [x] `env/bin/python -m pytest apps/medic_plus/medic_plus/tests/ui/test_daystar_health.py -v` — 13 passed (2 new: detail tab render, POPIA-clean response body)
- [x] Manual: Practice user clicks a row from the patients list → detail screen loads with all tabs.

## Surfaced gap

Wiring revealed that medic_plus ships **no Custom DocPerm fixtures** for the Practice Admin / Practice Doctor / Practice Receptionist roles, so real Practice users get 403 from Frappe's REST API on Patient (and related Healthcare doctypes) before the PQC even runs. Tracked separately in **#12** with a workaround (Physician role granted to selfserve.test). The dashboard works because its endpoint reads via `frappe.db.*` — those bypass role checks and apply only PQCs.

## Out of scope (next slice)

Profile + password change (#8) — last slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)