### PR TITLE
Wire Daystar Health profile + password change (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ MIT
 
 ## Changelog
 
+### 2026-04-29 — Phase 1J (Issue #8): Daystar Health profile + password change (final SPA slice)
+- Final slice of 5 wiring the `/daystar-health` SPA. Replaces the hardcoded provider profile with the logged-in user's real data and wires password change to Frappe's standard endpoint.
+- New endpoint `medic_plus.api.daystar_health.get_my_practitioner_profile` — joins User (name / email / phone / image) with Healthcare Practitioner (department / HPCSA / practice number) via the Practice Member row, plus a top-level `two_factor_authentication` boolean from `frappe.utils.user.user_has_2fa`.
+- Profile tab is **read-only** — fields render as styled disabled boxes; no Save button. Footer note directs users to their practice administrator for changes.
+- Security tab posts current/new/confirm to `frappe.core.doctype.user.user.update_password`. Inline success/error feedback. 2FA state shown read-only with pointer to Frappe Desk for setup.
+- Notifications tab removed from the profile sidebar — no schema backing (per Q8 design decision).
+- Sidebar "Sign out" button was a route-change-only no-op; now calls `meridianApi.logout()` to actually end the session.
+- Tests: 2 new Python (no-practice rejection + payload contract) + 2 new Playwright (read-only rendering + password change round-trip with a throwaway Practice user).
+- **SPA wiring Phase 1 complete** (#4 → #5 → #6 → #7 → #8). Outstanding: #12 (Custom DocPerm fixtures for Practice roles).
+
 ### 2026-04-29 — Phase 1I (Issue #7): Daystar Health patient detail wired to composite endpoint
 - Slice 4 of 5 wiring the `/daystar-health` SPA. Patient detail screen now hydrates all six tabs (Overview / Visits / Vitals / Medications / Labs / Notes) from a single composite call.
 - New deep module `api/patient_summary` — `build_patient_summary(patient_name, practice)` orchestrator + pure `_format_patient_summary(...)` helper that applies per-tab caps (20 / 12 for vitals) and the POPIA whitelist (only `name / patient_name / dob / sex / mobile / email / status` make it into the patient block; `custom_sa_id_number` is unreachable).

--- a/medic_plus/api/daystar_health.py
+++ b/medic_plus/api/daystar_health.py
@@ -25,6 +25,68 @@ def get_dashboard() -> dict:
     return build_dashboard(practice=practice, user=frappe.session.user)
 
 
+_USER_PROFILE_FIELDS = (
+    "name",
+    "first_name",
+    "last_name",
+    "email",
+    "phone",
+    "user_image",
+)
+
+_PRACTITIONER_PROFILE_FIELDS = (
+    "name",
+    "department",
+    "custom_hpcsa_number",
+    "custom_practice_number",
+)
+
+
+@frappe.whitelist()
+def get_my_practitioner_profile() -> dict:
+    """Return the read-only profile for the logged-in practitioner.
+
+    Joins ``User`` core fields with the ``Healthcare Practitioner`` linked
+    via the user's ``Practice Member`` row. Raises ``PermissionError`` for
+    callers without a Practice — the SPA surfaces that as the no-practice
+    error card, same as every other endpoint.
+    """
+    practice = get_active_practice()
+    user_email = frappe.session.user
+    user_row = frappe.db.get_value(
+        "User", user_email, list(_USER_PROFILE_FIELDS), as_dict=True
+    ) or {}
+    practitioner_name = frappe.db.get_value(
+        "Practice Member",
+        {"user": user_email, "practice": practice},
+        "practitioner",
+    )
+    practitioner_row = {}
+    if practitioner_name:
+        practitioner_row = frappe.db.get_value(
+            "Healthcare Practitioner",
+            practitioner_name,
+            list(_PRACTITIONER_PROFILE_FIELDS),
+            as_dict=True,
+        ) or {}
+    # 2FA per-user state is inferred from frappe.utils.user.user_has_2fa
+    # (the User doctype has no direct boolean for it). Returned as a flat
+    # field so the SPA can render an enabled/disabled badge without another
+    # round trip.
+    try:
+        from frappe.utils.user import user_has_2fa
+        twofa_enabled = bool(user_has_2fa(user_email))
+    except Exception:
+        twofa_enabled = False
+
+    return {
+        "user": dict(user_row),
+        "practitioner": dict(practitioner_row),
+        "practice": practice,
+        "two_factor_authentication": twofa_enabled,
+    }
+
+
 @frappe.whitelist()
 def get_patient_detail(patient: str) -> dict:
     """Return the composite payload for a Patient detail screen.

--- a/medic_plus/api/test_daystar_health.py
+++ b/medic_plus/api/test_daystar_health.py
@@ -278,6 +278,66 @@ class TestGetPatientDetailEndpoint(unittest.TestCase):
             with self.assertRaises(frappe.PermissionError):
                 m.get_patient_detail(patient="PAT-00001")
 
+    def test_get_my_practitioner_profile_rejects_no_practice_user(self):
+        """The profile screen requires a Practice context. A user without a
+        Practice Member row gets PermissionError from the resolver — same
+        no-practice path as every other Daystar Health endpoint."""
+        m = self._import()
+        with patch("medic_plus.api.daystar_health.get_active_practice",
+                   side_effect=frappe.PermissionError("no practice")):
+            with self.assertRaises(frappe.PermissionError):
+                m.get_my_practitioner_profile()
+
+    def test_get_my_practitioner_profile_returns_user_and_practitioner_fields(self):
+        """The profile payload joins the User core (name / email / phone) with
+        the Healthcare Practitioner linked via the user's Practice Member row.
+        Read-only this iteration — no editable fields, no Save affordance.
+        Surfaces enough to render the design (first/last name, email, phone,
+        specialty/department, HPCSA number, 2FA enabled state).
+        """
+        m = self._import()
+
+        user_row = {
+            "name": "doctor.a@example.test",
+            "first_name": "Aiyana",
+            "last_name": "Patel",
+            "email": "doctor.a@example.test",
+            "phone": "+27821234567",
+            "user_image": "/files/doctor.jpg",
+        }
+        practitioner_row = {
+            "name": "HLC-PRAC-2026-00118",
+            "department": "Family Medicine",
+            "custom_hpcsa_number": "MP123456",
+            "custom_practice_number": "0123456",
+        }
+
+        # Three frappe.db.get_value calls in order:
+        # 1. User row by email
+        # 2. Practice Member.practitioner link to find the practitioner name
+        # 3. Healthcare Practitioner row by name
+        with patch("medic_plus.api.daystar_health.get_active_practice",
+                   return_value="PRAC-00001"), \
+             patch("medic_plus.api.daystar_health.frappe.session",
+                   frappe._dict(user="doctor.a@example.test")), \
+             patch("medic_plus.api.daystar_health.frappe.db.get_value",
+                   side_effect=[user_row, "HLC-PRAC-2026-00118", practitioner_row]):
+            payload = m.get_my_practitioner_profile()
+
+        # Top-level keys describe the contract.
+        self.assertIn("user", payload)
+        self.assertIn("practitioner", payload)
+        # User block carries the rendered fields.
+        self.assertEqual(payload["user"]["first_name"], "Aiyana")
+        self.assertEqual(payload["user"]["email"], "doctor.a@example.test")
+        # 2FA state comes through at the top level as a boolean — the SPA
+        # renders an enabled badge from this without calling Frappe again.
+        # frappe.utils.user.user_has_2fa returns falsy for our mock setup.
+        self.assertIn("two_factor_authentication", payload)
+        # Practitioner block carries SA-specific fields.
+        self.assertEqual(payload["practitioner"]["custom_hpcsa_number"], "MP123456")
+        self.assertEqual(payload["practitioner"]["department"], "Family Medicine")
+
     def test_rejects_cross_tenant_patient_request(self):
         """A user signed into Practice A who requests a Patient that belongs
         to Practice B gets PermissionError — never the patient's data, never

--- a/medic_plus/public/daystar-health/meridian-layout.jsx
+++ b/medic_plus/public/daystar-health/meridian-layout.jsx
@@ -58,10 +58,10 @@ function MSidebar({ route, go }) {
       </div>
 
       <div style={{ padding: 12, borderTop: '1px solid var(--border)' }}>
-        <button className="nav-item" onClick={() => go('profile')}>
+        <button data-testid="nav-profile" className="nav-item" onClick={() => go('profile')}>
           <window.MIcons.Settings size={17} /><span>Account</span>
         </button>
-        <button className="nav-item" onClick={() => go('login')}>
+        <button data-testid="nav-signout" className="nav-item" onClick={() => window.meridianApi.logout()}>
           <window.MIcons.Logout size={17} /><span>Sign out</span>
         </button>
       </div>

--- a/medic_plus/public/daystar-health/meridian-profile.jsx
+++ b/medic_plus/public/daystar-health/meridian-profile.jsx
@@ -1,28 +1,61 @@
-// Profile (provider account)
+// Profile screen — wired to medic_plus.api.daystar_health.get_my_practitioner_profile.
+// Read-only profile this iteration. Security tab handles password change via
+// Frappe's standard /api/method/frappe.core.doctype.user.user.update_password.
+// Notifications tab is removed from the sidebar (no schema backing).
+
+const PROFILE_TABS = [
+  { id: 'account', label: 'Profile', icon: 'Users' },
+  { id: 'security', label: 'Sign-in & security', icon: 'Lock' },
+];
+
 function MProfileScreen({ go }) {
   const [tab, setTab] = mUseState('account');
-  const [form, setForm] = mUseState({
-    firstName: 'Sanjay', lastName: 'Patel', email: 's.patel@daystarhealth.co',
-    phone: '(415) 555-0142', npi: '1234567890', specialty: 'Family Medicine',
-    title: 'Attending Physician',
-  });
-  const upd = (k, v) => setForm(f => ({ ...f, [k]: v }));
+  const [state, setState] = mUseState({ status: 'loading', data: null, error: null });
+
+  mUseEffect(() => {
+    let cancelled = false;
+    setState({ status: 'loading', data: null, error: null });
+    window.meridianApi
+      .call('medic_plus.api.daystar_health.get_my_practitioner_profile')
+      .then(data => { if (!cancelled) setState({ status: 'ready', data, error: null }); })
+      .catch(err => {
+        if (cancelled) return;
+        const msg = err.message || 'Could not load profile.';
+        setState({ status: 'error', data: null, error: msg });
+        window.meridianApi.showError(msg);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (state.status === 'loading') return <ProfileSkeleton />;
+  if (state.status === 'error') {
+    return (
+      <div className="page fade-in">
+        <div className="card card-pad" data-testid="profile-error" style={{ textAlign: 'center', padding: 60 }}>
+          <h2 style={{ fontSize: 16, fontWeight: 600, margin: '0 0 8px' }}>Couldn't load profile</h2>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)' }}>{state.error}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="page fade-in">
+    <div className="page fade-in" data-testid="profile-page">
       <h1 style={{ fontSize: 22, fontWeight: 600, margin: '0 0 4px', letterSpacing: '-0.02em' }}>Account settings</h1>
-      <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: '0 0 20px' }}>Manage your provider profile, sign-in, and preferences.</p>
+      <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: '0 0 20px' }}>Manage your provider profile and sign-in.</p>
 
       <div style={{ display: 'grid', gridTemplateColumns: '220px 1fr', gap: 'var(--gap)' }}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          {[
-            { id: 'account', label: 'Profile', icon: 'Users' },
-            { id: 'security', label: 'Sign-in & security', icon: 'Lock' },
-            { id: 'notifications', label: 'Notifications', icon: 'Bell' },
-          ].map(t => {
+        <div data-testid="profile-tabs" style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {PROFILE_TABS.map(t => {
             const Ic = window.MIcons[t.icon];
             return (
-              <button key={t.id} className={`nav-item ${tab === t.id ? 'active' : ''}`} onClick={() => setTab(t.id)} style={{ marginBottom: 2 }}>
+              <button
+                key={t.id}
+                data-testid={`profile-tab-${t.id}`}
+                className={`nav-item ${tab === t.id ? 'active' : ''}`}
+                onClick={() => setTab(t.id)}
+                style={{ marginBottom: 2 }}
+              >
                 <Ic size={15} /><span>{t.label}</span>
               </button>
             );
@@ -30,88 +63,180 @@ function MProfileScreen({ go }) {
         </div>
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
-          {tab === 'account' && (
-            <>
-              <div className="card card-pad">
-                <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Profile photo</h3>
-                <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: '0 0 16px' }}>Shown to your team and on patient correspondence.</p>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
-                  <div className="avatar" style={{ width: 72, height: 72, fontSize: 24, borderRadius: 18 }}>SP</div>
-                  <div style={{ display: 'flex', gap: 8 }}>
-                    <button className="btn btn-secondary btn-sm">Upload new</button>
-                    <button className="btn btn-ghost btn-sm">Remove</button>
-                  </div>
-                </div>
-              </div>
+          {tab === 'account' && <AccountTab data={state.data} />}
+          {tab === 'security' && <SecurityTab data={state.data} />}
+        </div>
+      </div>
+    </div>
+  );
+}
 
-              <div className="card card-pad">
-                <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 16px' }}>Provider information</h3>
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
-                  <div className="field"><label className="label">First name</label><input className="input" value={form.firstName} onChange={e => upd('firstName', e.target.value)} /></div>
-                  <div className="field"><label className="label">Last name</label><input className="input" value={form.lastName} onChange={e => upd('lastName', e.target.value)} /></div>
-                  <div className="field"><label className="label">Title</label><input className="input" value={form.title} onChange={e => upd('title', e.target.value)} /></div>
-                  <div className="field"><label className="label">Specialty</label><input className="input" value={form.specialty} onChange={e => upd('specialty', e.target.value)} /></div>
-                  <div className="field"><label className="label">Work email</label><input className="input" type="email" value={form.email} onChange={e => upd('email', e.target.value)} /></div>
-                  <div className="field"><label className="label">Phone</label><input className="input" value={form.phone} onChange={e => upd('phone', e.target.value)} /></div>
-                  <div className="field"><label className="label">NPI number</label><input className="input mono" value={form.npi} onChange={e => upd('npi', e.target.value)} /></div>
-                </div>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18, paddingTop: 16, borderTop: '1px solid var(--border)' }}>
-                  <button className="btn btn-ghost btn-sm">Cancel</button>
-                  <button className="btn btn-primary btn-sm">Save changes</button>
-                </div>
-              </div>
-            </>
-          )}
+function AccountTab({ data }) {
+  const u = data.user || {};
+  const p = data.practitioner || {};
+  const initials = [(u.first_name || '?')[0], (u.last_name || '')[0]].filter(Boolean).join('').toUpperCase();
+  return (
+    <div data-testid="profile-tab-content-account" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
+      <div className="card card-pad">
+        <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Profile photo</h3>
+        <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: '0 0 16px' }}>Shown to your team and on patient correspondence.</p>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div className="avatar" style={{ width: 72, height: 72, fontSize: 24, borderRadius: 18 }}>{initials || '–'}</div>
+        </div>
+      </div>
 
-          {tab === 'security' && (
-            <>
-              <div className="card card-pad">
-                <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Password</h3>
-                <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: '0 0 16px' }}>Last changed 47 days ago. Practice policy requires rotation every 90 days.</p>
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
-                  <div className="field"><label className="label">Current password</label><input className="input" type="password" defaultValue="••••••••" /></div>
-                  <div />
-                  <div className="field"><label className="label">New password</label><input className="input" type="password" /></div>
-                  <div className="field"><label className="label">Confirm new</label><input className="input" type="password" /></div>
-                </div>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18, paddingTop: 16, borderTop: '1px solid var(--border)' }}>
-                  <button className="btn btn-primary btn-sm">Update password</button>
-                </div>
-              </div>
-              <div className="card card-pad">
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                  <div>
-                    <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Two-factor authentication</h3>
-                    <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: 0 }}>Required for HIPAA compliance. Currently using authenticator app.</p>
-                  </div>
-                  <span className="badge badge-success">Enabled</span>
-                </div>
-              </div>
-            </>
-          )}
+      <div className="card card-pad">
+        <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 16px' }}>Provider information</h3>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
+          <ReadOnlyField label="First name" value={u.first_name} testId="profile-first-name" />
+          <ReadOnlyField label="Last name" value={u.last_name} testId="profile-last-name" />
+          <ReadOnlyField label="Specialty / department" value={p.department} testId="profile-department" />
+          <ReadOnlyField label="HPCSA number" value={p.custom_hpcsa_number} mono testId="profile-hpcsa" />
+          <ReadOnlyField label="Practice number" value={p.custom_practice_number} mono testId="profile-practice-number" />
+          <ReadOnlyField label="Work email" value={u.email} testId="profile-email" />
+          <ReadOnlyField label="Phone" value={u.phone} testId="profile-phone" />
+        </div>
+        <p style={{ marginTop: 16, paddingTop: 14, borderTop: '1px solid var(--border)', fontSize: 11.5, color: 'var(--text-muted)', margin: '16px 0 0' }}>
+          Profile details are managed by your practice administrator. Contact them to make changes.
+        </p>
+      </div>
+    </div>
+  );
+}
 
-          {tab === 'notifications' && (
-            <div className="card card-pad">
-              <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 16px' }}>Notification preferences</h3>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-                {[
-                  { label: 'Critical lab results', sub: 'Notify me immediately when a result is flagged critical', on: true },
-                  { label: 'New patient messages', sub: 'Patient portal messages requiring a response', on: true },
-                  { label: 'Refill requests', sub: 'Pharmacy and patient-initiated refill requests', on: true },
-                  { label: 'Daily schedule digest', sub: 'Email summary of tomorrow\'s appointments at 6 PM', on: false },
-                ].map((n, i, arr) => (
-                  <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingBottom: 14, borderBottom: i < arr.length - 1 ? '1px solid var(--border)' : 'none' }}>
-                    <div>
-                      <div style={{ fontSize: 13.5, fontWeight: 500 }}>{n.label}</div>
-                      <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>{n.sub}</div>
-                    </div>
-                    <div className={`switch ${n.on ? 'on' : ''}`}><div className="dot" /></div>
-                  </div>
-                ))}
-              </div>
+function ReadOnlyField({ label, value, mono, testId }) {
+  return (
+    <div className="field">
+      <label className="label">{label}</label>
+      <div
+        data-testid={testId}
+        className={mono ? 'mono' : ''}
+        style={{
+          padding: '8px 12px',
+          background: 'var(--bg-subtle)',
+          border: '1px solid var(--border)',
+          borderRadius: 6,
+          fontSize: 13,
+          minHeight: 36,
+          display: 'flex',
+          alignItems: 'center',
+          color: value ? 'var(--text)' : 'var(--text-dim)',
+        }}
+      >
+        {value || '—'}
+      </div>
+    </div>
+  );
+}
+
+function SecurityTab({ data }) {
+  const [oldPw, setOldPw] = mUseState('');
+  const [newPw, setNewPw] = mUseState('');
+  const [confirm, setConfirm] = mUseState('');
+  const [submitting, setSubmitting] = mUseState(false);
+  const [feedback, setFeedback] = mUseState(null);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setFeedback(null);
+    if (!oldPw || !newPw) {
+      setFeedback({ kind: 'error', message: 'Enter your current and new password.' });
+      return;
+    }
+    if (newPw !== confirm) {
+      setFeedback({ kind: 'error', message: 'New password and confirmation do not match.' });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await window.meridianApi.call('frappe.core.doctype.user.user.update_password', {
+        new_password: newPw,
+        old_password: oldPw,
+        logout_all_sessions: 0,
+      });
+      setFeedback({ kind: 'success', message: 'Password updated. Use it next time you sign in.' });
+      setOldPw(''); setNewPw(''); setConfirm('');
+    } catch (err) {
+      setFeedback({ kind: 'error', message: err.message || 'Could not update password.' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div data-testid="profile-tab-content-security" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--gap)' }}>
+      <div className="card card-pad">
+        <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Password</h3>
+        <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: '0 0 16px' }}>Choose a new password. You'll stay signed in on this device.</p>
+        <form onSubmit={submit}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
+            <div className="field">
+              <label className="label">Current password</label>
+              <input data-testid="profile-current-password" className="input" type="password" value={oldPw} onChange={e => setOldPw(e.target.value)} required />
+            </div>
+            <div />
+            <div className="field">
+              <label className="label">New password</label>
+              <input data-testid="profile-new-password" className="input" type="password" value={newPw} onChange={e => setNewPw(e.target.value)} required minLength={8} />
+            </div>
+            <div className="field">
+              <label className="label">Confirm new</label>
+              <input data-testid="profile-confirm-password" className="input" type="password" value={confirm} onChange={e => setConfirm(e.target.value)} required minLength={8} />
+            </div>
+          </div>
+          {feedback && (
+            <div
+              role="alert"
+              data-testid={`profile-password-${feedback.kind}`}
+              style={{
+                marginTop: 14,
+                padding: '10px 12px',
+                background: feedback.kind === 'success' ? 'var(--success-soft)' : 'var(--danger-soft)',
+                border: `1px solid var(--${feedback.kind === 'success' ? 'success' : 'danger'})`,
+                borderRadius: 8,
+                fontSize: 12.5,
+                color: `var(--${feedback.kind === 'success' ? 'success' : 'danger'})`,
+              }}
+            >
+              {feedback.message}
             </div>
           )}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18, paddingTop: 16, borderTop: '1px solid var(--border)' }}>
+            <button data-testid="profile-update-password" type="submit" className="btn btn-primary btn-sm" disabled={submitting}>
+              {submitting ? 'Updating…' : 'Update password'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div className="card card-pad">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <div>
+            <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 4px' }}>Two-factor authentication</h3>
+            <p style={{ fontSize: 12.5, color: 'var(--text-muted)', margin: 0 }}>
+              {data.two_factor_authentication
+                ? 'Configured. Manage in the Frappe Desk under My Settings.'
+                : 'Not configured. Set up via the Frappe Desk under My Settings.'}
+            </p>
+          </div>
+          <span
+            data-testid="profile-2fa-status"
+            className={`badge ${data.two_factor_authentication ? 'badge-success' : 'badge-neutral'}`}
+          >
+            {data.two_factor_authentication ? 'Enabled' : 'Not configured'}
+          </span>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function ProfileSkeleton() {
+  return (
+    <div className="page fade-in" data-testid="profile-skeleton">
+      <div style={{ width: 220, height: 24, background: 'var(--bg-subtle)', borderRadius: 4, marginBottom: 24, animation: 'pulse 1.6s infinite' }} />
+      <div className="card card-pad">
+        <div style={{ width: '100%', height: 140, background: 'var(--bg-subtle)', borderRadius: 4, animation: 'pulse 1.6s infinite' }} />
       </div>
     </div>
   );

--- a/medic_plus/tests/ui/test_daystar_health.py
+++ b/medic_plus/tests/ui/test_daystar_health.py
@@ -33,7 +33,7 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from conftest import BASE_URL, ADMIN_USER, ADMIN_PASS
+from conftest import BASE_URL, ADMIN_USER, ADMIN_PASS, RUN_TAG
 
 
 DAYSTAR_URL = f"{BASE_URL}/daystar-health"
@@ -368,6 +368,33 @@ class TestPatientDetailRender:
             page.locator(f'[data-testid="patient-tab-{tab_id}"]').click()
             expect(page.locator(f'[data-testid="patient-tab-content-{tab_id}"]')).to_be_visible(timeout=5_000)
 
+    def test_profile_renders_read_only(self, admin_with_practice_membership, page: Page):
+        """The profile screen shows User + Practitioner fields read-only.
+        No editable inputs, no Save button. Notifications was a tab in the
+        old mock; it is removed from the SPA's profile sidebar."""
+        _login_as_admin(page)
+        page.goto(DAYSTAR_URL)
+        expect(page.locator('[data-testid="dashboard-ready"]')).to_be_visible(timeout=20_000)
+        page.locator('[data-testid="nav-profile"]').click()
+        expect(page.locator('[data-testid="profile-page"]')).to_be_visible(timeout=15_000)
+
+        # Two tabs only — Profile and Sign-in & security.
+        expect(page.locator('[data-testid="profile-tab-account"]')).to_be_visible()
+        expect(page.locator('[data-testid="profile-tab-security"]')).to_be_visible()
+        # Notifications tab is gone from the SPA's profile.
+        assert page.locator('text=Notifications').count() == 0, (
+            "Profile sidebar must not contain a Notifications tab"
+        )
+
+        # Read-only fields render the logged-in user's data. The text values
+        # come from the Administrator account.
+        expect(page.locator('[data-testid="profile-first-name"]')).to_be_visible()
+        expect(page.locator('[data-testid="profile-email"]')).to_be_visible()
+
+        # No Save Changes button anywhere on the Profile tab.
+        save_btn = page.locator('[data-testid="profile-tab-content-account"] button:has-text("Save changes")')
+        assert save_btn.count() == 0, "Profile is read-only; no Save button expected"
+
     def test_detail_payload_does_not_leak_custom_sa_id_number(self, admin_with_practice_membership, page: Page):
         """POPIA contract: the detail screen's payload must never contain the
         SA ID number. We grab the network response of the composite call and
@@ -398,3 +425,100 @@ class TestPatientDetailRender:
         assert "custom_sa_id_number" not in body, (
             "POPIA: the get_patient_detail response leaked custom_sa_id_number"
         )
+
+
+# ── slice 5: profile + password change ───────────────────────────────────────
+
+
+@pytest.fixture
+def throwaway_practice_user():
+    """Create a fresh user with a known password for the password-change test.
+
+    The test will change the password through the SPA and verify the new
+    password lets them sign in. The user is torn down afterwards (along with
+    its Practice Member row).
+    """
+    import os
+    os.chdir('/home/fruppa/frappe-bench/sites')
+    import frappe
+    frappe.init(site='medic-demo-staging.thedaystar.co.za')
+    frappe.connect()
+
+    email = f"daystar.pwtest.{RUN_TAG}@example.local"
+    initial_password = "InitialPw123!"
+
+    user = frappe.get_doc({
+        "doctype": "User",
+        "email": email,
+        "first_name": "PwTest",
+        "last_name": "User",
+        "send_welcome_email": 0,
+        "enabled": 1,
+        "user_type": "System User",
+    })
+    user.append("roles", {"role": "Physician"})
+    user.insert(ignore_permissions=True)
+    user.new_password = initial_password
+    user.save(ignore_permissions=True)
+
+    member = frappe.get_doc({
+        "doctype": "Practice Member",
+        "user": email,
+        "practice": "PRAC-00001",
+        "role": "Admin",
+        "status": "Accepted",
+        "full_name": "PwTest User",
+        "email": email,
+    })
+    member.insert(ignore_permissions=True)
+    frappe.db.commit()
+
+    yield {"email": email, "password": initial_password, "member_name": member.name}
+
+    frappe.delete_doc("Practice Member", member.name, ignore_permissions=True, force=True)
+    frappe.delete_doc("User", email, ignore_permissions=True, force=True)
+    frappe.db.commit()
+    frappe.destroy()
+
+
+class TestProfilePasswordChange:
+    """The Security tab posts current/new password to Frappe's standard
+    update_password endpoint. After a successful change the user can sign
+    in with the new password — proven by signing out and signing back in."""
+
+    def test_password_change_round_trip(self, throwaway_practice_user, page: Page):
+        email = throwaway_practice_user["email"]
+        old_pw = throwaway_practice_user["password"]
+        new_pw = f"RoundTrip{RUN_TAG}!"
+
+        # 1. Sign in with the initial password.
+        page.goto(f"{BASE_URL}/login")
+        page.locator("#login_email").fill(email)
+        page.locator("#login_password").fill(old_pw)
+        page.locator(".btn-login[type='submit']").click()
+        page.wait_for_url(re.compile(r"/(app|desk)"), timeout=15_000)
+
+        # 2. Open the SPA → profile → security tab → change password.
+        page.goto(DAYSTAR_URL)
+        expect(page.locator('[data-testid="dashboard-ready"]')).to_be_visible(timeout=20_000)
+        page.locator('[data-testid="nav-profile"]').click()
+        expect(page.locator('[data-testid="profile-page"]')).to_be_visible(timeout=10_000)
+        page.locator('[data-testid="profile-tab-security"]').click()
+        expect(page.locator('[data-testid="profile-tab-content-security"]')).to_be_visible()
+
+        page.locator('[data-testid="profile-current-password"]').fill(old_pw)
+        page.locator('[data-testid="profile-new-password"]').fill(new_pw)
+        page.locator('[data-testid="profile-confirm-password"]').fill(new_pw)
+        page.locator('[data-testid="profile-update-password"]').click()
+
+        # Success feedback appears in-page.
+        expect(page.locator('[data-testid="profile-password-success"]')).to_be_visible(timeout=15_000)
+
+        # 3. Sign out, then sign back in with the new password.
+        page.context.clear_cookies()
+        page.goto(f"{BASE_URL}/login")
+        page.locator("#login_email").fill(email)
+        page.locator("#login_password").fill(new_pw)
+        page.locator(".btn-login[type='submit']").click()
+        page.wait_for_url(re.compile(r"/(app|desk)"), timeout=15_000)
+        # If we got here, the new password works end-to-end.

--- a/techspec.md
+++ b/techspec.md
@@ -4,6 +4,41 @@ Living technical specification. Every feature, bugfix, refactor, and design deci
 
 ---
 
+## 2026-04-29 — Phase 1J (Issue #8): Daystar Health profile — wired + password change
+
+### Scope
+Slice 5 of 5 (final) wiring `/daystar-health`. Replaces the hardcoded provider profile with the logged-in user's real data, and wires the password-change form to Frappe's standard endpoint. Notifications tab is removed from the SPA's profile sidebar — no schema backing.
+
+### Endpoint: `daystar_health.get_my_practitioner_profile()`
+Joins User core (name, email, phone, user_image) with the Healthcare Practitioner linked via the user's Practice Member row (department, HPCSA number, practice number). Adds a top-level `two_factor_authentication` boolean derived from `frappe.utils.user.user_has_2fa` since User has no direct 2FA field.
+
+Same `frappe.PermissionError` no-practice gate as every other Daystar Health endpoint.
+
+### Frontend rewire (`meridian-profile.jsx`)
+- Three render states: skeleton, error card, ready (two tabs only — Account, Security).
+- **Profile tab**: read-only fields rendered as styled disabled boxes (`<ReadOnlyField>` helper). No "Save changes" button anywhere on the tab. Footer note tells the user to contact their practice administrator for changes.
+- **Security tab**: password-change form (current / new / confirm) posts to `frappe.core.doctype.user.user.update_password`. Success/error feedback inline. 2FA shown read-only with status badge ("Enabled" / "Not configured") and a pointer to the Frappe Desk for setup.
+- **Notifications tab removed** — no `User Notification Preference` doctype, so any UI we'd ship would be misleading.
+
+### Sidebar fix
+The bottom-of-sidebar "Sign out" button was wired to `go('login')` — that just changed the SPA route; the Frappe session was untouched. Fixed to call `window.meridianApi.logout()` so it actually ends the session. Also added `data-testid="nav-profile"` and `data-testid="nav-signout"` on those buttons.
+
+### Tests
+- Python: 2 new — endpoint rejects no-practice user (tracer); endpoint returns the documented payload (User + Practitioner blocks + 2FA boolean).
+- Playwright: 2 new — profile renders read-only with no Save button + Notifications tab absent; password change round-trip (uses a throwaway Practice user fixture, changes the password through the SPA, then signs in with the new password to prove end-to-end).
+
+### Slice 5 wraps Phase 1 of the SPA wiring (#4 → #5 → #6 → #7 → #8)
+The five issues delivered:
+- #4 — auth flow + foundation (`practice_resolver`, page bootstrap, `meridian-api.js`)
+- #5 — dashboard composite + frontend
+- #6 — patients list (REST resource API + server-side search/pagination)
+- #7 — patient detail composite (POPIA-filtered, per-tab capped)
+- #8 — profile read-only + password change
+
+Outstanding follow-up: **Issue #12** (Custom DocPerm fixtures for Practice roles) — currently unblocked on staging via a Physician role on the test user, but needs to land before the SPA can serve real Practice users without that workaround.
+
+---
+
 ## 2026-04-29 — Phase 1I (Issue #7): Daystar Health patient detail — wired to composite endpoint
 
 ### Scope


### PR DESCRIPTION
Closes #8. **Final slice (5 of 5)** wiring `/daystar-health`. Replaces the hardcoded provider profile with the logged-in user's real data and wires password change to Frappe's standard endpoint.

## Summary

- **Endpoint** `medic_plus.api.daystar_health.get_my_practitioner_profile` — joins User (name / email / phone / image) with Healthcare Practitioner (department / HPCSA / practice number) via Practice Member, plus a `two_factor_authentication` boolean from `frappe.utils.user.user_has_2fa`. Same `PermissionError` no-practice gate as every other endpoint.
- **Profile tab** is **read-only** — fields render as styled disabled boxes via a `ReadOnlyField` helper, no Save button. Footer note directs users to their practice administrator for changes.
- **Security tab** posts current/new/confirm to `frappe.core.doctype.user.user.update_password`; inline success/error feedback. 2FA enabled state shown read-only with a pointer to the Frappe Desk.
- **Notifications tab removed** from the profile sidebar (no schema backing).
- **Sidebar Sign-out fix** — the bottom-of-sidebar "Sign out" button was wired to `go('login')`, which only changed the SPA route; the Frappe session was untouched. Now calls `meridianApi.logout()` so it actually ends the session.

## Test plan

- [x] `env/bin/python -m pytest apps/medic_plus/medic_plus/api/test_daystar_health.py -v` — 17 passed (2 new: no-practice rejection + payload contract)
- [x] `env/bin/python -m pytest apps/medic_plus/medic_plus/tests/ui/test_daystar_health.py -v` — 15 passed (2 new: profile read-only render + password change round-trip with a throwaway Practice user)
- [x] Manual: signed into the SPA as a Practice user, changed password, signed out, signed back in with the new password.

## SPA Phase 1 complete

This wraps the Daystar Health SPA wiring across 5 issues:
- #4 — auth flow + foundation (`practice_resolver`, page bootstrap, `meridian-api.js`)
- #5 — dashboard composite + frontend
- #6 — patients list (REST resource API + server-side search/pagination)
- #7 — patient detail composite (POPIA-filtered, per-tab capped)
- #8 — profile read-only + password change (this PR)

## Outstanding

- **#12** — Custom DocPerm fixtures for Practice Admin / Practice Doctor / Practice Receptionist roles. Currently unblocked on staging via a `Physician` role granted to the `selfserve.test` user, but needs to land before the SPA can serve real Practice users without that workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)