### PR TITLE
fix(daystar-health): drop hardcoded "12" badge from Appointments nav

### DIFF
--- a/medic_plus/public/daystar-health/meridian-layout.jsx
+++ b/medic_plus/public/daystar-health/meridian-layout.jsx
@@ -4,7 +4,7 @@ const { useState: mUseState, useMemo: mUseMemo, useEffect: mUseEffect } = React;
 function MSidebar({ route, go }) {
   const items = [
     { key: 'dashboard', icon: 'Home', label: 'Today' },
-    { key: 'appointments', icon: 'Calendar', label: 'Appointments', count: 12 },
+    { key: 'appointments', icon: 'Calendar', label: 'Appointments' },
     { key: 'patients', icon: 'Users', label: 'Patients' },
     { key: 'records', icon: 'ClipBoard', label: 'Medical Records' },
     { key: 'labs', icon: 'Beaker', label: 'Labs & Imaging' },


### PR DESCRIPTION
## Summary
- The Meridian sidebar shipped with `count: 12` hardcoded next to **Appointments** — a leftover from the design mock that rendered regardless of real data.
- Drop the field. The existing `{it.count && ...}` guard hides the badge when the field is absent, so no JSX changes needed.

## Test plan
- [x] Hard-refresh `https://selfserve.thedaystar.co.za/daystar-health` and confirm no badge next to **Appointments** (also verified locally before pushing).
- [ ] (Future) Wire to real today's-appointment count from `get_dashboard` if/when we want a live badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)