### PR TITLE
fix: alias ehealth → medic-demo + derive FHIR base URL from active host

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -118,15 +118,17 @@ jobs:
       - name: Health check
         run: |
           sleep 5
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Host: medic-demo.thedaystar.co.za" \
-            http://${{ secrets.PROD_HOST }} || echo "000")
-          echo "Health check HTTP status: $STATUS"
-          if [[ "$STATUS" != "2"* && "$STATUS" != "3"* ]]; then
-            echo "HEALTH CHECK FAILED — status $STATUS"
-            exit 1
-          fi
-          echo "Health check passed."
+          for HOST in medic-demo.thedaystar.co.za ehealth.thedaystar.co.za; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Host: $HOST" \
+              http://${{ secrets.PROD_HOST }} || echo "000")
+            echo "Health check $HOST: HTTP $STATUS"
+            if [[ "$STATUS" != "2"* && "$STATUS" != "3"* ]]; then
+              echo "HEALTH CHECK FAILED for $HOST — status $STATUS"
+              exit 1
+            fi
+          done
+          echo "Health check passed (both hostnames)."
 
       - name: Notify Slack (optional)
         if: always()

--- a/TRAINING_MANUAL.md
+++ b/TRAINING_MANUAL.md
@@ -729,12 +729,12 @@ Types: `feat`, `fix`, `test`, `docs`, `refactor`, `chore`
 
 ### Two-server setup
 
-| Server | Role | URL |
-|--------|------|-----|
-| This VPS (staging) | Development & testing | `medic-demo-staging.thedaystar.co.za` |
-| Remote VPS (production) | Live site | `medic-demo.thedaystar.co.za` |
+| Server | Role | URL | Aliases |
+|--------|------|-----|---------|
+| This VPS (staging) | Development & testing | `medic-demo-staging.thedaystar.co.za` | `selfserve.thedaystar.co.za`, `ehealth-staging.thedaystar.co.za` |
+| Remote VPS (production) | Live site | `medic-demo.thedaystar.co.za` | `ehealth.thedaystar.co.za` |
 
-Code moves only via Git. Databases are never synced between environments.
+Code moves only via Git. Databases are never synced between environments. Aliases are nginx-level — both hostnames hit the same Frappe site, so users can transition off the legacy hostname without coordination.
 
 ### Production deploy
 

--- a/medic_plus/api/fhir/capability_statement.py
+++ b/medic_plus/api/fhir/capability_statement.py
@@ -7,7 +7,10 @@ AllergyIntolerance, Observation.
 
 from __future__ import annotations
 
-_FHIR_BASE_URL = "https://medic-demo-staging.thedaystar.co.za/api/fhir/R4"
+
+def _fhir_base_url() -> str:
+	import frappe
+	return f"{frappe.utils.get_url()}/api/fhir/R4"
 
 _RESOURCES = [
 	{
@@ -69,7 +72,7 @@ def build() -> dict:
 		},
 		"implementation": {
 			"description": "Medic Plus FHIR endpoint",
-			"url": _FHIR_BASE_URL,
+			"url": _fhir_base_url(),
 		},
 		"rest": [
 			{

--- a/medic_plus/api/fhir/mappers.py
+++ b/medic_plus/api/fhir/mappers.py
@@ -17,7 +17,8 @@ _CS_LOINC = "http://loinc.org"
 _CS_SNOMED = "http://snomed.info/sct"
 _CS_TARIFF = "https://www.bhf.co.za/sama-tariff"
 
-_FHIR_BASE_URL = "https://medic-demo-staging.thedaystar.co.za/api/fhir/R4"
+def _fhir_base_url() -> str:
+	return f"{frappe.utils.get_url()}/api/fhir/R4"
 
 
 # ---------------------------------------------------------------------------
@@ -33,7 +34,7 @@ def patient_to_fhir(patient_name: str) -> dict:
 		"identifier": [
 			{
 				"use": "official",
-				"system": f"{_FHIR_BASE_URL}/naming-system/medic-plus-patient",
+				"system": f"{_fhir_base_url()}/naming-system/medic-plus-patient",
 				"value": p.name,
 			}
 		],

--- a/techspec.md
+++ b/techspec.md
@@ -1390,6 +1390,19 @@ Side-effect from cherry-pick `55bdf3b`: `create_practitioner` and `create_practi
 
 ---
 
+## 2026-05-09 — ehealth alias + FHIR base-URL fix
+
+Added `ehealth.thedaystar.co.za` as an nginx alias for the production Frappe site `medic-demo.thedaystar.co.za`, and `ehealth-staging.thedaystar.co.za` for `medic-demo-staging.thedaystar.co.za`. Both hostnames serve the same Frappe site; users can transition off the legacy `medic-demo` hostnames at their own pace.
+
+Implementation:
+- Staging: `bench setup add-domain` adds the alias to `site_config.json["domains"]`; LE cert (`booking-staging.thedaystar.co.za`) expanded to cover the new SAN.
+- Production: per-site SSL conf at `/etc/nginx/conf.d/frappe-sites-ssl.conf` updated to add `ehealth.thedaystar.co.za` to the `medic-demo` `server_name`; cert `medic-demo.thedaystar.co.za` expanded to cover both names.
+- Deploy workflow `.github/workflows/deploy-production.yml` health-check now hits both hostnames so an alias regression fails CI.
+
+Incidental fix: `medic_plus.api.fhir.capability_statement._FHIR_BASE_URL` and `medic_plus.api.fhir.mappers._FHIR_BASE_URL` were hard-coded to `https://medic-demo-staging.thedaystar.co.za/api/fhir/R4`. On production this meant FHIR `id` system URIs and CapabilityStatement `implementation.url` pointed at staging — wrong for any real client. Replaced both with `frappe.utils.get_url()` so the URL is derived per-request from the active host. Now correct on prod, staging, and aliases.
+
+---
+
 ## Roadmap
 
 - [ ] Prescription print format — Jinja, per-practice letterhead ✅ Done (Phase 1D)


### PR DESCRIPTION
## Summary
- nginx alias: `ehealth-staging.thedaystar.co.za` → `medic-demo-staging.thedaystar.co.za` (live on staging) and `ehealth.thedaystar.co.za` → `medic-demo.thedaystar.co.za` (applied directly on prod, not in repo). Both hostnames serve the same Frappe site — users can transition off the legacy `medic-demo` hostnames at their own pace.
- **Bugfix**: `_FHIR_BASE_URL` in `capability_statement.py` and `mappers.py` was hardcoded to staging. On production this meant FHIR `id` system URIs and `CapabilityStatement.implementation.url` pointed at `medic-demo-staging` — wrong for any real client. Replaced with `frappe.utils.get_url()` so URL is derived per-request.
- Deploy workflow health check now hits both hostnames so an alias regression fails CI.

## Verification
- Staging alias: `curl -sI https://ehealth-staging.thedaystar.co.za/` returns `HTTP/2 200`, same `<title>Login</title>` as `medic-demo-staging`.
- FHIR base URL: bench shell on `medic-demo-staging` now returns `https://medic-demo-staging.thedaystar.co.za/api/fhir/R4` (derived) instead of the previous hardcoded constant. Prod will return `https://medic-demo.thedaystar.co.za/...`.
- AST-parse + smoke-call of `build()` and `_fhir_base_url()` succeed.

## Test plan
- [ ] `bench --site medic-demo-staging.thedaystar.co.za run-tests --app medic_plus --skip-before-tests` passes (focused on FHIR tests).
- [ ] Browse `https://ehealth-staging.thedaystar.co.za/` — should be the medic_plus login screen.
- [ ] Browse `https://ehealth.thedaystar.co.za/` (after prod script runs) — should be the medic_plus login screen.
- [ ] After tag + deploy: `curl https://medic-demo.thedaystar.co.za/api/method/medic_plus.api.fhir.router.capability_statement` returns CapabilityStatement with `implementation.url=https://medic-demo.thedaystar.co.za/api/fhir/R4`.