### PR TITLE
feat(daystar-health): branded pickers in new-visit drawer

### DIFF
--- a/medic_plus/public/daystar-health/meridian-date-picker.jsx
+++ b/medic_plus/public/daystar-health/meridian-date-picker.jsx
@@ -1,0 +1,339 @@
+// MDatePicker — branded date picker for the daystar-health portal.
+//
+// API mirrors the spirit of react-aria-components' <DatePicker>:
+//   <window.MDatePicker
+//     value="YYYY-MM-DD"           // string, "" when empty
+//     onChange={(v) => ...}        // receives a string (NOT a synthetic event)
+//     onBlur={() => ...}           // fires when the trigger input blurs
+//     min="YYYY-MM-DD"             // optional lower bound (inclusive)
+//     max="YYYY-MM-DD"             // optional upper bound (inclusive)
+//     disabled={false}
+//     placeholder="YYYY-MM-DD"
+//     aria-label="..."             // forwarded to the input
+//     data-testid="..."            // forwarded to the input
+//     className="..."              // appended to the input class list
+//     style={{...}}                // applied to the wrapper
+//   />
+//
+// Why portal the popover to <body>: the patients page wraps its content in
+// `.page.fade-in`, whose keyframes apply `transform: translateY(...)`. Any
+// `position: absolute|fixed` descendant would be trapped in that ancestor's
+// stacking context and could paint behind sibling cards (see register-patient
+// drawer fix). Portalling avoids that class of bug entirely.
+
+const { useState: dpUseState, useEffect: dpUseEffect, useRef: dpUseRef, useMemo: dpUseMemo } = React;
+
+const DP_WEEKDAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];  // ISO week (Mon-first)
+const DP_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function dpPad(n) { return n < 10 ? `0${n}` : `${n}`; }
+function dpToISO(y, m, d) { return `${y}-${dpPad(m)}-${dpPad(d)}`; }
+function dpParse(value) {
+  if (!value || !DP_DATE_RE.test(value)) return null;
+  const [y, m, d] = value.split("-").map(Number);
+  // Validate with a real Date to catch e.g. 2026-02-30.
+  const date = new Date(y, m - 1, d);
+  if (date.getFullYear() !== y || date.getMonth() !== m - 1 || date.getDate() !== d) return null;
+  return { y, m, d };
+}
+function dpDaysInMonth(y, m) { return new Date(y, m, 0).getDate(); }
+// Monday = 0 ... Sunday = 6. JS getDay is Sun=0 ... Sat=6.
+function dpWeekdayMonFirst(y, m, d) { return (new Date(y, m - 1, d).getDay() + 6) % 7; }
+
+function dpFormatDisplay(value) {
+  const parts = dpParse(value);
+  if (!parts) return "";
+  try {
+    return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "2-digit" })
+      .format(new Date(parts.y, parts.m - 1, parts.d));
+  } catch (e) {
+    return value;
+  }
+}
+
+function dpClampToBounds(parts, min, max) {
+  if (!parts) return null;
+  const iso = dpToISO(parts.y, parts.m, parts.d);
+  if (min && iso < min) return dpParse(min);
+  if (max && iso > max) return dpParse(max);
+  return parts;
+}
+
+function MDatePicker(props) {
+  const {
+    value, onChange, onBlur,
+    min, max, disabled,
+    placeholder = "YYYY-MM-DD",
+    className, style,
+    ...rest
+  } = props;
+
+  const [text, setText] = dpUseState(value || "");
+  const [open, setOpen] = dpUseState(false);
+  const [popoverRect, setPopoverRect] = dpUseState({ top: 0, left: 0, width: 280 });
+
+  // viewMonth is the calendar's cursor — what month grid we render.
+  const initialView = dpUseMemo(() => {
+    const p = dpParse(value) || dpParse(min) || dpParse(max);
+    if (p) return { y: p.y, m: p.m };
+    const now = new Date();
+    return { y: now.getFullYear(), m: now.getMonth() + 1 };
+  }, []);
+  const [view, setView] = dpUseState(initialView);
+
+  const wrapperRef = dpUseRef(null);
+  const inputRef = dpUseRef(null);
+  const popoverRef = dpUseRef(null);
+
+  // Sync external value → local text. Skip while user is typing (input focused)
+  // so we don't clobber in-progress edits.
+  dpUseEffect(() => {
+    if (document.activeElement !== inputRef.current) {
+      setText(value || "");
+    }
+  }, [value]);
+
+  // Position popover under the input each time it opens / on viewport change.
+  const reposition = () => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const width = Math.max(rect.width, 280);
+    const popH = 320;  // approx; we re-fit below
+    let top = rect.bottom + 6;
+    if (top + popH > window.innerHeight && rect.top - 6 - popH > 0) {
+      top = rect.top - 6 - popH;  // flip above
+    }
+    let left = rect.left;
+    if (left + width > window.innerWidth - 8) left = window.innerWidth - 8 - width;
+    if (left < 8) left = 8;
+    setPopoverRect({ top: top + window.scrollY, left: left + window.scrollX, width });
+  };
+
+  dpUseEffect(() => {
+    if (!open) return;
+    reposition();
+    const onScrollOrResize = () => reposition();
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, [open]);
+
+  // Close on outside click / Escape.
+  dpUseEffect(() => {
+    if (!open) return;
+    const onDocDown = (e) => {
+      if (wrapperRef.current?.contains(e.target)) return;
+      if (popoverRef.current?.contains(e.target)) return;
+      setOpen(false);
+    };
+    const onKey = (e) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        inputRef.current?.focus();
+      }
+    };
+    document.addEventListener("mousedown", onDocDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const openWith = () => {
+    if (disabled) return;
+    const parts = dpParse(text || value);
+    if (parts) setView({ y: parts.y, m: parts.m });
+    setOpen(true);
+  };
+
+  const commit = (iso) => {
+    setText(iso);
+    onChange && onChange(iso);
+  };
+
+  const onInputChange = (e) => {
+    const raw = e.target.value;
+    setText(raw);
+    // Only propagate well-formed values upstream. Garbage stays local until
+    // blur, which lets the user finish typing.
+    if (raw === "") {
+      onChange && onChange("");
+    } else if (DP_DATE_RE.test(raw) && dpParse(raw)) {
+      onChange && onChange(raw);
+    }
+  };
+
+  const onInputBlur = (e) => {
+    // If text is unparseable, snap back to the canonical value.
+    const parsed = dpParse(text);
+    if (!parsed && text !== "") {
+      setText(value || "");
+    }
+    onBlur && onBlur(e);
+  };
+
+  const pickDay = (y, m, d) => {
+    const iso = dpToISO(y, m, d);
+    if ((min && iso < min) || (max && iso > max)) return;
+    commit(iso);
+    setOpen(false);
+    inputRef.current?.focus();
+  };
+
+  const stepMonth = (delta) => {
+    let { y, m } = view;
+    m += delta;
+    while (m < 1) { m += 12; y -= 1; }
+    while (m > 12) { m -= 12; y += 1; }
+    setView({ y, m });
+  };
+
+  const today = new Date();
+  const todayISO = dpToISO(today.getFullYear(), today.getMonth() + 1, today.getDate());
+  const selected = dpParse(value);
+
+  // Build the day grid: 6 weeks × 7 days, leading blanks before day 1.
+  const grid = dpUseMemo(() => {
+    const lead = dpWeekdayMonFirst(view.y, view.m, 1);
+    const days = dpDaysInMonth(view.y, view.m);
+    const cells = [];
+    for (let i = 0; i < lead; i++) cells.push(null);
+    for (let d = 1; d <= days; d++) cells.push(d);
+    while (cells.length % 7 !== 0) cells.push(null);
+    while (cells.length < 42) cells.push(null);  // always render 6 rows
+    return cells;
+  }, [view.y, view.m]);
+
+  const monthLabel = dpUseMemo(() => {
+    try {
+      return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "long" })
+        .format(new Date(view.y, view.m - 1, 1));
+    } catch (e) {
+      return `${view.y}-${dpPad(view.m)}`;
+    }
+  }, [view.y, view.m]);
+
+  const popover = open ? ReactDOM.createPortal(
+    <div
+      ref={popoverRef}
+      className="mdp-popover"
+      role="dialog"
+      aria-label="Choose date"
+      style={{ top: popoverRect.top, left: popoverRect.left, width: popoverRect.width }}
+    >
+      <div className="mdp-header">
+        <button type="button" className="mdp-nav" aria-label="Previous month" onClick={() => stepMonth(-1)}>
+          <window.MIcons.ChevronLeft size={14} />
+        </button>
+        <div className="mdp-month-label" data-testid="mdp-month-label">{monthLabel}</div>
+        <button type="button" className="mdp-nav" aria-label="Next month" onClick={() => stepMonth(1)}>
+          <window.MIcons.ChevronRight size={14} />
+        </button>
+      </div>
+
+      <div className="mdp-weekdays">
+        {DP_WEEKDAYS.map((w) => <div key={w}>{w}</div>)}
+      </div>
+
+      <div className="mdp-grid" role="grid">
+        {grid.map((d, i) => {
+          if (d == null) return <div key={i} className="mdp-cell mdp-cell-empty" />;
+          const iso = dpToISO(view.y, view.m, d);
+          const isSelected = selected && selected.y === view.y && selected.m === view.m && selected.d === d;
+          const isToday = iso === todayISO;
+          const outOfRange = (min && iso < min) || (max && iso > max);
+          let cls = "mdp-cell";
+          if (isSelected) cls += " mdp-cell-selected";
+          if (isToday && !isSelected) cls += " mdp-cell-today";
+          if (outOfRange) cls += " mdp-cell-disabled";
+          return (
+            <button
+              key={i}
+              type="button"
+              role="gridcell"
+              aria-selected={isSelected || undefined}
+              aria-disabled={outOfRange || undefined}
+              className={cls}
+              disabled={outOfRange}
+              onClick={() => pickDay(view.y, view.m, d)}
+              data-testid={isSelected ? "mdp-day-selected" : undefined}
+              data-iso={iso}
+            >
+              {d}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mdp-footer">
+        <button
+          type="button"
+          className="mdp-foot-btn"
+          onClick={() => {
+            const t = dpClampToBounds(dpParse(todayISO), min, max);
+            if (!t) return;
+            const iso = dpToISO(t.y, t.m, t.d);
+            setView({ y: t.y, m: t.m });
+            commit(iso);
+            setOpen(false);
+            inputRef.current?.focus();
+          }}
+        >
+          Today
+        </button>
+        <button
+          type="button"
+          className="mdp-foot-btn"
+          onClick={() => {
+            commit("");
+            setOpen(false);
+            inputRef.current?.focus();
+          }}
+        >
+          Clear
+        </button>
+      </div>
+    </div>,
+    document.body
+  ) : null;
+
+  return (
+    <div className={`mdp${disabled ? " mdp-disabled" : ""}`} ref={wrapperRef} style={style}>
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="numeric"
+        pattern="\d{4}-\d{2}-\d{2}"
+        autoComplete="off"
+        spellCheck={false}
+        className={`input mdp-input ${className || ""}`}
+        placeholder={placeholder}
+        value={text}
+        onChange={onInputChange}
+        onBlur={onInputBlur}
+        onFocus={() => { /* don't auto-open — typists don't want it */ }}
+        onKeyDown={(e) => { if (e.key === "ArrowDown" && !open) { e.preventDefault(); openWith(); } }}
+        disabled={disabled}
+        {...rest}
+      />
+      <button
+        type="button"
+        className="mdp-icon-btn"
+        aria-label="Open calendar"
+        tabIndex={-1}
+        onClick={() => (open ? setOpen(false) : openWith())}
+        disabled={disabled}
+      >
+        <window.MIcons.Calendar size={15} />
+      </button>
+      {popover}
+    </div>
+  );
+}
+
+window.MDatePicker = MDatePicker;

--- a/medic_plus/public/daystar-health/meridian-new-visit.jsx
+++ b/medic_plus/public/daystar-health/meridian-new-visit.jsx
@@ -6,18 +6,24 @@
 // Sections: Schedule → SOAP → Examination Findings → Orders.
 // Examination Findings and Orders are child-table rows appended before POST.
 
-function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
-  const api = window.meridianApi || {};
-  const today = new Date().toISOString().slice(0, 10);
+const NV_SECTIONS = [
+  { id: 'schedule', label: 'Schedule' },
+  { id: 'soap', label: 'SOAP Notes' },
+  { id: 'exam', label: 'Examination' },
+  { id: 'orders', label: 'Orders' },
+];
 
-  // ── Scheduling fields ──────────────────────────────────────────────────────
-  const [form, setForm] = React.useState({
-    patient: prefillPatient || '',
+const NV_BODY_SYSTEMS = ['General', 'Cardiovascular', 'Respiratory', 'Gastrointestinal',
+  'Neurological', 'Musculoskeletal', 'Dermatological', 'ENT', 'Ophthalmology',
+  'Genitourinary', 'Endocrine', 'Psychiatric', 'Other'];
+
+function nvInitialForm(today) {
+  return {
+    patient: '',
     practitioner: '',
     encounter_date: today,
     encounter_time: '09:00',
     appointment_type: '',
-    // SOAP
     chief_complaint: '',
     hopi: '',
     subjective: '',
@@ -25,13 +31,99 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
     assessment_text: '',
     assessment_code: '',
     plan: '',
-  });
+  };
+}
 
-  // ── Child rows ─────────────────────────────────────────────────────────────
+// Module-scope so React keeps a stable component identity across MNewVisitDrawer
+// re-renders. Defining this inside the parent caused every input to remount on
+// every keystroke (and lose focus, popover state, etc.).
+function NVField({ label, children, span = 1 }) {
+  return (
+    <label
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        fontSize: 12,
+        color: 'var(--text-muted)',
+        gridColumn: span > 1 ? `span ${span}` : undefined,
+      }}
+    >
+      <span style={{ fontWeight: 500 }}>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function NVSectionTabs({ active, onSelect }) {
+  const onKey = (e) => {
+    const idx = NV_SECTIONS.findIndex((s) => s.id === active);
+    if (idx < 0) return;
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      onSelect(NV_SECTIONS[(idx + 1) % NV_SECTIONS.length].id);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      onSelect(NV_SECTIONS[(idx - 1 + NV_SECTIONS.length) % NV_SECTIONS.length].id);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      onSelect(NV_SECTIONS[0].id);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      onSelect(NV_SECTIONS[NV_SECTIONS.length - 1].id);
+    }
+  };
+  return (
+    <div
+      role="tablist"
+      aria-label="Encounter sections"
+      onKeyDown={onKey}
+      style={{ display: 'flex', borderBottom: '1px solid var(--border-color)', marginBottom: 16, gap: 0 }}
+    >
+      {NV_SECTIONS.map((s) => {
+        const isActive = s.id === active;
+        return (
+          <button
+            key={s.id}
+            type="button"
+            role="tab"
+            id={`new-visit-tab-${s.id}`}
+            aria-selected={isActive}
+            aria-controls={`new-visit-panel-${s.id}`}
+            tabIndex={isActive ? 0 : -1}
+            data-testid={`visit-tab-${s.id}`}
+            onClick={() => onSelect(s.id)}
+            style={{
+              padding: '6px 14px',
+              fontSize: 12,
+              border: 'none',
+              cursor: 'pointer',
+              borderBottom: isActive ? '2px solid var(--primary)' : '2px solid transparent',
+              background: 'none',
+              fontWeight: isActive ? 600 : 400,
+              color: isActive ? 'var(--text-color)' : 'var(--text-muted)',
+            }}
+          >
+            {s.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
+  const api = window.meridianApi || {};
+  const today = new Date().toISOString().slice(0, 10);
+
+  const [form, setForm] = React.useState(() => ({
+    ...nvInitialForm(today),
+    patient: prefillPatient || '',
+  }));
+
   const [examFindings, setExamFindings] = React.useState([]);
   const [orders, setOrders] = React.useState([]);
 
-  // ── Remote data ────────────────────────────────────────────────────────────
   const [patients, setPatients] = React.useState([]);
   const [practitioners, setPractitioners] = React.useState([]);
   const [appointmentTypes, setAppointmentTypes] = React.useState([]);
@@ -40,46 +132,61 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
 
   const [submitting, setSubmitting] = React.useState(false);
   const [error, setError] = React.useState(null);
+  const [missingFields, setMissingFields] = React.useState(() => new Set());
   const [activeSection, setActiveSection] = React.useState('schedule');
 
-  // ── Load reference lists on open ──────────────────────────────────────────
+  // Load reference lists when the drawer opens. Cancellation flag prevents
+  // late responses from updating state after the drawer closes.
   React.useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     setError(null);
+    setMissingFields(new Set());
     setActiveSection('schedule');
     api.resource('Patient', { fields: JSON.stringify(['name', 'patient_name']), order_by: 'patient_name asc', limit_page_length: 200 })
-      .then((rows) => setPatients((rows && rows.data) || []))
-      .catch(() => setPatients([]));
+      .then((rows) => { if (!cancelled) setPatients((rows && rows.data) || []); })
+      .catch(() => { if (!cancelled) setPatients([]); });
     api.resource('Healthcare Practitioner', { fields: JSON.stringify(['name', 'practitioner_name']), order_by: 'practitioner_name asc', limit_page_length: 200 })
-      .then((rows) => setPractitioners((rows && rows.data) || []))
-      .catch(() => setPractitioners([]));
+      .then((rows) => { if (!cancelled) setPractitioners((rows && rows.data) || []); })
+      .catch(() => { if (!cancelled) setPractitioners([]); });
     api.resource('Appointment Type', { fields: JSON.stringify(['name']), order_by: 'name asc', limit_page_length: 200 })
       .then((rows) => {
+        if (cancelled) return;
         const list = (rows && rows.data) || [];
         setAppointmentTypes(list);
         setForm((f) => f.appointment_type || !list.length ? f : { ...f, appointment_type: list[0].name });
       })
-      .catch(() => setAppointmentTypes([]));
+      .catch(() => { if (!cancelled) setAppointmentTypes([]); });
+    return () => { cancelled = true; };
   }, [open]);
 
   React.useEffect(() => {
     if (open && prefillPatient) setForm((f) => ({ ...f, patient: prefillPatient }));
   }, [open, prefillPatient]);
 
-  // ── ICD-10 search (debounced 300ms) ────────────────────────────────────────
+  // ICD-10 search (debounced 300ms). Cancellation flag drops late responses.
   React.useEffect(() => {
     if (!icd10Query || icd10Query.length < 2) { setIcd10Results([]); return; }
+    let cancelled = false;
     const timer = setTimeout(() => {
       api.call('medic_plus.api.daystar_health.search_icd10', { query: icd10Query, limit: 10 })
-        .then((res) => setIcd10Results((res && res.message) || []))
-        .catch(() => setIcd10Results([]));
+        .then((res) => { if (!cancelled) setIcd10Results((res && res.message) || []); })
+        .catch(() => { if (!cancelled) setIcd10Results([]); });
     }, 300);
-    return () => clearTimeout(timer);
+    return () => { cancelled = true; clearTimeout(timer); };
   }, [icd10Query]);
 
-  const update = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+  const update = (k, v) => {
+    setForm((f) => ({ ...f, [k]: v }));
+    if (missingFields.has(k) && v) {
+      setMissingFields((prev) => {
+        const next = new Set(prev);
+        next.delete(k);
+        return next;
+      });
+    }
+  };
 
-  // ── Examination Findings helpers ───────────────────────────────────────────
   const addFinding = () => setExamFindings((prev) => [
     ...prev,
     { body_system: 'General', body_part: '', finding: '', is_abnormal: 0 },
@@ -87,7 +194,6 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
   const updateFinding = (i, k, v) => setExamFindings((prev) => prev.map((r, idx) => idx === i ? { ...r, [k]: v } : r));
   const removeFinding = (i) => setExamFindings((prev) => prev.filter((_, idx) => idx !== i));
 
-  // ── Orders helpers ─────────────────────────────────────────────────────────
   const addOrder = () => setOrders((prev) => [
     ...prev,
     { order_type: 'Lab', order_name: '', status: 'Draft' },
@@ -95,14 +201,21 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
   const updateOrder = (i, k, v) => setOrders((prev) => prev.map((r, idx) => idx === i ? { ...r, [k]: v } : r));
   const removeOrder = (i) => setOrders((prev) => prev.filter((_, idx) => idx !== i));
 
-  // ── Submit ─────────────────────────────────────────────────────────────────
   const submit = async () => {
-    if (!form.patient || !form.practitioner || !form.encounter_date || !form.chief_complaint) {
+    const missing = new Set();
+    if (!form.patient) missing.add('patient');
+    if (!form.practitioner) missing.add('practitioner');
+    if (!form.encounter_date) missing.add('encounter_date');
+    if (!form.chief_complaint) missing.add('chief_complaint');
+    if (missing.size > 0) {
+      setMissingFields(missing);
       setError('Patient, practitioner, date and chief complaint are required.');
+      setActiveSection('schedule');
       return;
     }
     setSubmitting(true);
     setError(null);
+    setMissingFields(new Set());
     try {
       const payload = {
         doctype: 'Patient Encounter',
@@ -149,13 +262,7 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
       }
       const created = (data && (data.message || data)) || null;
       if (onCreated) onCreated(created);
-      // Reset for next open
-      setForm({
-        patient: '', practitioner: '', encounter_date: today,
-        encounter_time: '09:00', appointment_type: '',
-        chief_complaint: '', hopi: '', subjective: '',
-        objective: '', assessment_text: '', assessment_code: '', plan: '',
-      });
+      setForm(nvInitialForm(today));
       setExamFindings([]);
       setOrders([]);
       setIcd10Query('');
@@ -168,32 +275,8 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
     }
   };
 
-  // ── Layout helpers ─────────────────────────────────────────────────────────
-  const Field = ({ label, children, span = 1 }) => (
-    <label style={{ display: 'flex', flexDirection: 'column', gap: 6, fontSize: 12, color: 'var(--text-muted)', gridColumn: span > 1 ? `span ${span}` : undefined }}>
-      <span style={{ fontWeight: 500 }}>{label}</span>
-      {children}
-    </label>
-  );
-
-  const SectionTab = ({ id, label }) => (
-    <button
-      data-testid={`visit-tab-${id}`}
-      onClick={() => setActiveSection(id)}
-      style={{
-        padding: '6px 14px', fontSize: 12, border: 'none', cursor: 'pointer',
-        borderBottom: activeSection === id ? '2px solid var(--primary)' : '2px solid transparent',
-        background: 'none', fontWeight: activeSection === id ? 600 : 400,
-        color: activeSection === id ? 'var(--text-color)' : 'var(--text-muted)',
-      }}
-    >
-      {label}
-    </button>
-  );
-
-  const BODY_SYSTEMS = ['General', 'Cardiovascular', 'Respiratory', 'Gastrointestinal',
-    'Neurological', 'Musculoskeletal', 'Dermatological', 'ENT', 'Ophthalmology',
-    'Genitourinary', 'Endocrine', 'Psychiatric', 'Other'];
+  const ariaInvalid = (k) => (missingFields.has(k) ? 'true' : undefined);
+  const ariaDescribedBy = (k) => (missingFields.has(k) ? 'new-visit-error' : undefined);
 
   return (
     <window.MDrawer
@@ -215,53 +298,77 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
       }
     >
       {error && (
-        <div className="card" style={{ marginBottom: 12, padding: 10, background: 'var(--danger-soft)', borderColor: 'var(--danger)' }}>
+        <div
+          className="card"
+          id="new-visit-error"
+          role="alert"
+          aria-live="assertive"
+          style={{ marginBottom: 12, padding: 10, background: 'var(--danger-soft)', borderColor: 'var(--danger)' }}
+        >
           <div style={{ fontSize: 13, color: '#b91c1c' }}>{error}</div>
         </div>
       )}
 
-      {/* Section tabs */}
-      <div style={{ display: 'flex', borderBottom: '1px solid var(--border-color)', marginBottom: 16, gap: 0 }}>
-        <SectionTab id="schedule" label="Schedule" />
-        <SectionTab id="soap" label="SOAP Notes" />
-        <SectionTab id="exam" label="Examination" />
-        <SectionTab id="orders" label="Orders" />
-      </div>
+      <NVSectionTabs active={activeSection} onSelect={setActiveSection} />
 
       {/* ── Schedule ───────────────────────────────────────────────────────── */}
       {activeSection === 'schedule' && (
-        <div style={{ display: 'grid', gap: 14, gridTemplateColumns: '1fr 1fr' }}>
-          <Field label="Patient">
-            <select data-testid="new-visit-patient" value={form.patient} onChange={(e) => update('patient', e.target.value)} className="input">
-              <option value="">Select patient…</option>
-              {patients.map((p) => (
-                <option key={p.name} value={p.name}>{p.patient_name || p.name}</option>
-              ))}
-            </select>
-          </Field>
-          <Field label="Practitioner">
-            <select data-testid="new-visit-practitioner" value={form.practitioner} onChange={(e) => update('practitioner', e.target.value)} className="input">
-              <option value="">Select practitioner…</option>
-              {practitioners.map((p) => (
-                <option key={p.name} value={p.name}>{p.practitioner_name || p.name}</option>
-              ))}
-            </select>
-          </Field>
-          <Field label="Date">
-            <input type="date" data-testid="new-visit-date" value={form.encounter_date} onChange={(e) => update('encounter_date', e.target.value)} className="input" />
-          </Field>
-          <Field label="Time">
-            <input type="time" data-testid="new-visit-time" value={form.encounter_time} onChange={(e) => update('encounter_time', e.target.value)} className="input" />
-          </Field>
-          <Field label="Type" span={2}>
-            <select data-testid="new-visit-type" value={form.appointment_type} onChange={(e) => update('appointment_type', e.target.value)} className="input">
-              <option value="">Select type…</option>
-              {appointmentTypes.map((t) => (
-                <option key={t.name} value={t.name}>{t.name}</option>
-              ))}
-            </select>
-          </Field>
-          <Field label="Chief Complaint" span={2}>
+        <div
+          role="tabpanel"
+          id="new-visit-panel-schedule"
+          aria-labelledby="new-visit-tab-schedule"
+          style={{ display: 'grid', gap: 14, gridTemplateColumns: '1fr 1fr' }}
+        >
+          <NVField label="Patient">
+            <window.MSelect
+              data-testid="new-visit-patient"
+              value={form.patient}
+              onChange={(v) => update('patient', v)}
+              options={patients.map((p) => ({ value: p.name, label: p.patient_name || p.name }))}
+              placeholder="Select patient…"
+              searchable
+              aria-invalid={ariaInvalid('patient')}
+              aria-describedby={ariaDescribedBy('patient')}
+            />
+          </NVField>
+          <NVField label="Practitioner">
+            <window.MSelect
+              data-testid="new-visit-practitioner"
+              value={form.practitioner}
+              onChange={(v) => update('practitioner', v)}
+              options={practitioners.map((p) => ({ value: p.name, label: p.practitioner_name || p.name }))}
+              placeholder="Select practitioner…"
+              searchable
+              aria-invalid={ariaInvalid('practitioner')}
+              aria-describedby={ariaDescribedBy('practitioner')}
+            />
+          </NVField>
+          <NVField label="Date">
+            <window.MDatePicker
+              data-testid="new-visit-date"
+              value={form.encounter_date}
+              onChange={(v) => update('encounter_date', v)}
+              aria-invalid={ariaInvalid('encounter_date')}
+              aria-describedby={ariaDescribedBy('encounter_date')}
+            />
+          </NVField>
+          <NVField label="Time">
+            <window.MTimePicker
+              data-testid="new-visit-time"
+              value={form.encounter_time}
+              onChange={(v) => update('encounter_time', v)}
+            />
+          </NVField>
+          <NVField label="Type" span={2}>
+            <window.MSelect
+              data-testid="new-visit-type"
+              value={form.appointment_type}
+              onChange={(v) => update('appointment_type', v)}
+              options={appointmentTypes.map((t) => ({ value: t.name, label: t.name }))}
+              placeholder="Select type…"
+            />
+          </NVField>
+          <NVField label="Chief Complaint" span={2}>
             <input
               type="text"
               data-testid="new-visit-chief-complaint"
@@ -269,15 +376,22 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
               onChange={(e) => update('chief_complaint', e.target.value)}
               className="input"
               placeholder="Presenting complaint…"
+              aria-invalid={ariaInvalid('chief_complaint')}
+              aria-describedby={ariaDescribedBy('chief_complaint')}
             />
-          </Field>
+          </NVField>
         </div>
       )}
 
       {/* ── SOAP Notes ─────────────────────────────────────────────────────── */}
       {activeSection === 'soap' && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-          <Field label="History of Presenting Illness">
+        <div
+          role="tabpanel"
+          id="new-visit-panel-soap"
+          aria-labelledby="new-visit-tab-soap"
+          style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
+        >
+          <NVField label="History of Presenting Illness">
             <textarea
               data-testid="new-visit-hopi"
               rows={3}
@@ -287,8 +401,8 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
               style={{ resize: 'vertical', minHeight: 60 }}
               placeholder="Background and history…"
             />
-          </Field>
-          <Field label="Subjective (S)">
+          </NVField>
+          <NVField label="Subjective (S)">
             <textarea
               data-testid="new-visit-subjective"
               rows={3}
@@ -298,8 +412,8 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
               style={{ resize: 'vertical', minHeight: 60 }}
               placeholder="Patient's description of symptoms…"
             />
-          </Field>
-          <Field label="Objective (O)">
+          </NVField>
+          <NVField label="Objective (O)">
             <textarea
               data-testid="new-visit-objective"
               rows={3}
@@ -309,8 +423,8 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
               style={{ resize: 'vertical', minHeight: 60 }}
               placeholder="Vital signs, physical findings…"
             />
-          </Field>
-          <Field label="Assessment (A)">
+          </NVField>
+          <NVField label="Assessment (A)">
             <textarea
               data-testid="new-visit-assessment-text"
               rows={2}
@@ -320,9 +434,8 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
               style={{ resize: 'vertical', minHeight: 48 }}
               placeholder="Clinical impression / diagnosis…"
             />
-          </Field>
-          {/* ICD-10 code picker */}
-          <Field label="ICD-10 Code">
+          </NVField>
+          <NVField label="ICD-10 Code">
             <div style={{ position: 'relative' }}>
               {form.assessment_code ? (
                 <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
@@ -373,8 +486,8 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
                 </>
               )}
             </div>
-          </Field>
-          <Field label="Plan (P)">
+          </NVField>
+          <NVField label="Plan (P)">
             <textarea
               data-testid="new-visit-plan"
               rows={3}
@@ -384,13 +497,17 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
               style={{ resize: 'vertical', minHeight: 60 }}
               placeholder="Treatment plan, follow-up, referrals…"
             />
-          </Field>
+          </NVField>
         </div>
       )}
 
       {/* ── Examination Findings ───────────────────────────────────────────── */}
       {activeSection === 'exam' && (
-        <div>
+        <div
+          role="tabpanel"
+          id="new-visit-panel-exam"
+          aria-labelledby="new-visit-tab-exam"
+        >
           {examFindings.length === 0 && (
             <div style={{ color: 'var(--text-muted)', fontSize: 13, marginBottom: 12 }}>
               No examination findings added.
@@ -404,14 +521,11 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
             >
               <div>
                 <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 3 }}>System</div>
-                <select
+                <window.MSelect
                   value={row.body_system}
-                  onChange={(e) => updateFinding(i, 'body_system', e.target.value)}
-                  className="input"
-                  style={{ fontSize: 12 }}
-                >
-                  {BODY_SYSTEMS.map((s) => <option key={s} value={s}>{s}</option>)}
-                </select>
+                  onChange={(v) => updateFinding(i, 'body_system', v)}
+                  options={NV_BODY_SYSTEMS.map((s) => ({ value: s, label: s }))}
+                />
               </div>
               <div>
                 <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 3 }}>Body Part</div>
@@ -435,7 +549,14 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
                   style={{ fontSize: 12 }}
                 />
               </div>
-              <button className="btn btn-ghost btn-xs" onClick={() => removeFinding(i)} title="Remove">✕</button>
+              <button
+                className="btn btn-ghost btn-xs"
+                onClick={() => removeFinding(i)}
+                aria-label={`Remove finding ${i + 1}`}
+                title="Remove"
+              >
+                ✕
+              </button>
             </div>
           ))}
           <button
@@ -451,7 +572,11 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
 
       {/* ── Encounter Orders ───────────────────────────────────────────────── */}
       {activeSection === 'orders' && (
-        <div>
+        <div
+          role="tabpanel"
+          id="new-visit-panel-orders"
+          aria-labelledby="new-visit-tab-orders"
+        >
           {orders.length === 0 && (
             <div style={{ color: 'var(--text-muted)', fontSize: 13, marginBottom: 12 }}>
               No orders added.
@@ -465,17 +590,16 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
             >
               <div>
                 <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 3 }}>Type</div>
-                <select
+                <window.MSelect
                   value={row.order_type}
-                  onChange={(e) => updateOrder(i, 'order_type', e.target.value)}
-                  className="input"
-                  style={{ fontSize: 12 }}
-                >
-                  <option value="Lab">Lab</option>
-                  <option value="Imaging">Imaging</option>
-                  <option value="Referral">Referral</option>
-                  <option value="Immunisation">Immunisation</option>
-                </select>
+                  onChange={(v) => updateOrder(i, 'order_type', v)}
+                  options={[
+                    { value: 'Lab', label: 'Lab' },
+                    { value: 'Imaging', label: 'Imaging' },
+                    { value: 'Referral', label: 'Referral' },
+                    { value: 'Immunisation', label: 'Immunisation' },
+                  ]}
+                />
               </div>
               <div>
                 <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 3 }}>Order Name</div>
@@ -488,7 +612,14 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
                   style={{ fontSize: 12 }}
                 />
               </div>
-              <button className="btn btn-ghost btn-xs" onClick={() => removeOrder(i)} title="Remove">✕</button>
+              <button
+                className="btn btn-ghost btn-xs"
+                onClick={() => removeOrder(i)}
+                aria-label={`Remove order ${i + 1}`}
+                title="Remove"
+              >
+                ✕
+              </button>
             </div>
           ))}
           <button
@@ -506,341 +637,3 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
 }
 
 window.MNewVisitDrawer = MNewVisitDrawer;
-
-// ─── Phase 1D: Prescription Panel ──────────────────────────────────────────
-//
-// MPrescriptionPanel — manage a Drug Prescription child-table in the context
-// of a Patient Encounter.
-//
-// Props:
-//   patient         string   — Patient name (for live allergy checks)
-//   prescriber      string   — Healthcare Practitioner name (for Schedule checks)
-//   rows            array    — controlled drug-prescription rows
-//   onChange        fn(rows) — called on any row mutation
-//   disabled        bool     — lock the panel (e.g. encounter is submitted)
-//
-// Each row: { nappi_code_value, drug_name, schedule, strength, dosage_form,
-//             dosage, period, custom_repeats_authorised, custom_repeats_remaining,
-//             custom_generic_substitution_allowed, _override_reason }
-//
-// The panel calls check_prescription_safety on every NAPPI change and renders
-// orange warning badges per row.  When a warning badge is clicked an override
-// reason textarea opens; once filled the badge turns grey ("Override noted").
-
-const EMPTY_RX_ROW = () => ({
-  nappi_code_value: '',
-  drug_name: '',
-  schedule: '',
-  strength: '',
-  dosage_form: '',
-  dosage: '',
-  period: '',
-  custom_repeats_authorised: 0,
-  custom_generic_substitution_allowed: 0,
-  _override_reason: '',
-  _warnings: [],
-  _override_open: false,
-});
-
-function MPrescriptionRow({ row, idx, patient, prescriber, onUpdate, onRemove, disabled }) {
-  const api = window.meridianApi || {};
-
-  // Fetch Drug Master metadata when NAPPI CV changes
-  React.useEffect(() => {
-    if (!row.nappi_code_value) return;
-    let cancelled = false;
-    api.call('medic_plus.api.daystar_health.get_drug_master_by_nappi', {
-      nappi_code_value: row.nappi_code_value,
-    }).then((dm) => {
-      if (cancelled || !dm) return;
-      onUpdate(idx, {
-        drug_name: dm.drug_name || row.drug_name,
-        schedule: dm.schedule || '',
-        strength: dm.strength || '',
-        dosage_form: dm.dosage_form || '',
-      });
-    }).catch(() => {});
-    return () => { cancelled = true; };
-  }, [row.nappi_code_value]);
-
-  // Live allergy/schedule warnings when patient + nappi CV are set
-  React.useEffect(() => {
-    if (!row.nappi_code_value || !patient) {
-      onUpdate(idx, { _warnings: [] });
-      return;
-    }
-    let cancelled = false;
-    api.call('medic_plus.api.daystar_health.check_prescription_safety', {
-      patient,
-      nappi_code_values: JSON.stringify([row.nappi_code_value]),
-    }).then((ws) => {
-      if (!cancelled) onUpdate(idx, { _warnings: ws || [] });
-    }).catch(() => {
-      if (!cancelled) onUpdate(idx, { _warnings: [] });
-    });
-    return () => { cancelled = true; };
-  }, [row.nappi_code_value, patient]);
-
-  const hasUncovered = row._warnings.length > 0 && !row._override_reason;
-  const hasCovered   = row._warnings.length > 0 && !!row._override_reason;
-
-  const inputStyle = { fontSize: 12, padding: '4px 8px', borderRadius: 4,
-    border: '1px solid var(--border)', background: 'var(--input-bg, #fff)',
-    color: 'var(--text-dark)', width: '100%', boxSizing: 'border-box' };
-  const labelStyle = { fontSize: 11, color: 'var(--text-muted)', display: 'block',
-    marginBottom: 2 };
-
-  return (
-    <div
-      data-testid={`rx-row-${idx}`}
-      style={{
-        border: `1px solid ${hasUncovered ? 'var(--warning, #f59e0b)' : 'var(--border)'}`,
-        borderRadius: 8, padding: 12, marginBottom: 10,
-        background: hasUncovered ? 'var(--warning-soft, #fffbeb)' : 'var(--surface)',
-        position: 'relative',
-      }}
-    >
-      {/* Remove button */}
-      {!disabled && (
-        <button
-          type="button"
-          data-testid={`rx-row-remove-${idx}`}
-          onClick={() => onRemove(idx)}
-          style={{ position: 'absolute', top: 8, right: 8, background: 'none', border: 'none',
-            cursor: 'pointer', fontSize: 14, color: 'var(--text-muted)', lineHeight: 1 }}
-          title="Remove drug"
-        >✕</button>
-      )}
-
-      {/* NAPPI picker + drug name */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 8 }}>
-        <div>
-          <label style={labelStyle}>NAPPI Medicine *</label>
-          <window.MNappiPicker
-            value={row.nappi_code_value}
-            testid={`rx-nappi-${idx}`}
-            onChange={({ code, display }) =>
-              onUpdate(idx, { nappi_code_value: `${code}-NAPPI`, drug_name: display })
-            }
-          />
-        </div>
-        <div>
-          <label style={labelStyle}>Drug Name</label>
-          <input
-            type="text"
-            data-testid={`rx-drugname-${idx}`}
-            value={row.drug_name}
-            onChange={(e) => onUpdate(idx, { drug_name: e.target.value })}
-            style={inputStyle}
-            disabled={disabled}
-          />
-        </div>
-      </div>
-
-      {/* Schedule / Strength / Form */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8, marginBottom: 8 }}>
-        <div>
-          <label style={labelStyle}>Schedule</label>
-          <input
-            type="text"
-            data-testid={`rx-sched-${idx}`}
-            value={row.schedule}
-            readOnly
-            style={{ ...inputStyle, background: 'var(--bg-subtle)', color: 'var(--text-muted)' }}
-          />
-        </div>
-        <div>
-          <label style={labelStyle}>Strength</label>
-          <input
-            type="text"
-            value={row.strength}
-            onChange={(e) => onUpdate(idx, { strength: e.target.value })}
-            style={inputStyle}
-            disabled={disabled}
-          />
-        </div>
-        <div>
-          <label style={labelStyle}>Dosage Form</label>
-          <input
-            type="text"
-            value={row.dosage_form}
-            onChange={(e) => onUpdate(idx, { dosage_form: e.target.value })}
-            style={inputStyle}
-            disabled={disabled}
-          />
-        </div>
-      </div>
-
-      {/* Dosage / Duration / Repeats / Generic sub */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: 8 }}>
-        <div>
-          <label style={labelStyle}>Dosage</label>
-          <input
-            type="text"
-            data-testid={`rx-dosage-${idx}`}
-            value={row.dosage}
-            onChange={(e) => onUpdate(idx, { dosage: e.target.value })}
-            placeholder="e.g. 1 tablet BD"
-            style={inputStyle}
-            disabled={disabled}
-          />
-        </div>
-        <div>
-          <label style={labelStyle}>Duration</label>
-          <input
-            type="text"
-            value={row.period}
-            onChange={(e) => onUpdate(idx, { period: e.target.value })}
-            placeholder="e.g. 7 days"
-            style={inputStyle}
-            disabled={disabled}
-          />
-        </div>
-        <div>
-          <label style={labelStyle}>Repeats Authorised</label>
-          <input
-            type="number"
-            min="0"
-            data-testid={`rx-repeats-${idx}`}
-            value={row.custom_repeats_authorised}
-            onChange={(e) => onUpdate(idx, { custom_repeats_authorised: Number(e.target.value) })}
-            style={inputStyle}
-            disabled={disabled}
-          />
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, paddingTop: 16 }}>
-          <input
-            type="checkbox"
-            id={`rx-gensub-${idx}`}
-            checked={!!row.custom_generic_substitution_allowed}
-            onChange={(e) => onUpdate(idx, { custom_generic_substitution_allowed: e.target.checked ? 1 : 0 })}
-            disabled={disabled}
-          />
-          <label htmlFor={`rx-gensub-${idx}`} style={{ fontSize: 11, cursor: 'pointer' }}>
-            Generic sub
-          </label>
-        </div>
-      </div>
-
-      {/* Warning badges */}
-      {row._warnings.length > 0 && (
-        <div style={{ marginTop: 6 }}>
-          {row._warnings.map((w, wi) => (
-            <span
-              key={wi}
-              data-testid={`rx-warning-badge-${idx}-${wi}`}
-              title={w.message}
-              style={{
-                display: 'inline-block', fontSize: 10, padding: '2px 8px',
-                borderRadius: 12, marginRight: 6, marginBottom: 4, cursor: 'pointer',
-                background: hasCovered ? 'var(--text-muted)' : 'var(--warning, #f59e0b)',
-                color: '#fff', fontWeight: 600,
-              }}
-              onClick={() => onUpdate(idx, { _override_open: !row._override_open })}
-            >
-              {hasCovered ? '✓ Override noted' : `⚠ ${w.type === 'drug_allergy' ? 'Allergy' : w.type === 'schedule_rule' ? 'Schedule' : 'Interaction'}`}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {/* Override reason (expands when a warning badge is clicked or when warnings exist) */}
-      {row._warnings.length > 0 && (row._override_open || hasUncovered) && (
-        <div
-          data-testid={`rx-override-${idx}`}
-          style={{
-            marginTop: 8, padding: 8, background: 'var(--warning-soft, #fffbeb)',
-            border: '1px solid var(--warning, #f59e0b)', borderRadius: 6,
-          }}
-        >
-          <label style={{ ...labelStyle, fontWeight: 600, color: '#92400e' }}>
-            Override reason (required to proceed) *
-          </label>
-          <textarea
-            data-testid={`rx-override-reason-${idx}`}
-            rows={2}
-            value={row._override_reason}
-            onChange={(e) => onUpdate(idx, { _override_reason: e.target.value })}
-            placeholder="Clinical justification for overriding the warning…"
-            style={{ ...inputStyle, resize: 'vertical', minHeight: 48 }}
-            disabled={disabled}
-          />
-          {row._warnings.map((w, wi) => (
-            <p key={wi} style={{ fontSize: 10, color: '#92400e', margin: '4px 0 0' }}>
-              {w.message}
-            </p>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function MPrescriptionPanel({ patient, prescriber, rows, onChange, disabled = false }) {
-  const addRow = () => onChange([...rows, EMPTY_RX_ROW()]);
-
-  const updateRow = (idx, patch) => {
-    const updated = rows.map((r, i) => i === idx ? { ...r, ...patch } : r);
-    onChange(updated);
-  };
-
-  const removeRow = (idx) => onChange(rows.filter((_, i) => i !== idx));
-
-  const hasUncoveredWarnings = rows.some(
-    (r) => r._warnings && r._warnings.length > 0 && !r._override_reason
-  );
-
-  return (
-    <div data-testid="prescription-panel">
-      {rows.length === 0 && (
-        <div
-          data-testid="rx-empty"
-          style={{ textAlign: 'center', color: 'var(--text-muted)', fontSize: 12,
-            padding: '16px 0', borderRadius: 8, border: '1px dashed var(--border)' }}
-        >
-          No medications added yet.
-        </div>
-      )}
-
-      {rows.map((row, idx) => (
-        <MPrescriptionRow
-          key={idx}
-          row={row}
-          idx={idx}
-          patient={patient}
-          prescriber={prescriber}
-          onUpdate={updateRow}
-          onRemove={removeRow}
-          disabled={disabled}
-        />
-      ))}
-
-      {!disabled && (
-        <button
-          type="button"
-          data-testid="rx-add-drug"
-          onClick={addRow}
-          className="btn btn-outline btn-sm"
-          style={{ marginTop: 4 }}
-        >
-          + Add drug
-        </button>
-      )}
-
-      {hasUncoveredWarnings && (
-        <div
-          data-testid="rx-uncovered-warning-notice"
-          style={{
-            marginTop: 10, padding: '8px 12px', background: 'var(--warning-soft, #fffbeb)',
-            border: '1px solid var(--warning, #f59e0b)', borderRadius: 6,
-            fontSize: 12, color: '#92400e', fontWeight: 500,
-          }}
-        >
-          ⚠ One or more safety warnings require an override reason before saving.
-        </div>
-      )}
-    </div>
-  );
-}
-
-window.MPrescriptionPanel = MPrescriptionPanel;

--- a/medic_plus/public/daystar-health/meridian-prescription.jsx
+++ b/medic_plus/public/daystar-health/meridian-prescription.jsx
@@ -1,0 +1,334 @@
+// Phase 1D: Prescription Panel
+//
+// MPrescriptionPanel — manage a Drug Prescription child-table in the context
+// of a Patient Encounter.
+//
+// Props:
+//   patient         string   — Patient name (for live allergy checks)
+//   prescriber      string   — Healthcare Practitioner name (for Schedule checks)
+//   rows            array    — controlled drug-prescription rows
+//   onChange        fn(rows) — called on any row mutation
+//   disabled        bool     — lock the panel (e.g. encounter is submitted)
+//
+// Each row: { nappi_code_value, drug_name, schedule, strength, dosage_form,
+//             dosage, period, custom_repeats_authorised, custom_repeats_remaining,
+//             custom_generic_substitution_allowed, _override_reason }
+//
+// The panel calls check_prescription_safety on every NAPPI change and renders
+// orange warning badges per row.  When a warning badge is clicked an override
+// reason textarea opens; once filled the badge turns grey ("Override noted").
+
+const EMPTY_RX_ROW = () => ({
+  nappi_code_value: '',
+  drug_name: '',
+  schedule: '',
+  strength: '',
+  dosage_form: '',
+  dosage: '',
+  period: '',
+  custom_repeats_authorised: 0,
+  custom_generic_substitution_allowed: 0,
+  _override_reason: '',
+  _warnings: [],
+  _override_open: false,
+});
+
+function MPrescriptionRow({ row, idx, patient, prescriber, onUpdate, onRemove, disabled }) {
+  const api = window.meridianApi || {};
+
+  // Fetch Drug Master metadata when NAPPI CV changes
+  React.useEffect(() => {
+    if (!row.nappi_code_value) return;
+    let cancelled = false;
+    api.call('medic_plus.api.daystar_health.get_drug_master_by_nappi', {
+      nappi_code_value: row.nappi_code_value,
+    }).then((dm) => {
+      if (cancelled || !dm) return;
+      onUpdate(idx, {
+        drug_name: dm.drug_name || row.drug_name,
+        schedule: dm.schedule || '',
+        strength: dm.strength || '',
+        dosage_form: dm.dosage_form || '',
+      });
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [row.nappi_code_value]);
+
+  // Live allergy/schedule warnings when patient + nappi CV are set
+  React.useEffect(() => {
+    if (!row.nappi_code_value || !patient) {
+      onUpdate(idx, { _warnings: [] });
+      return;
+    }
+    let cancelled = false;
+    api.call('medic_plus.api.daystar_health.check_prescription_safety', {
+      patient,
+      nappi_code_values: JSON.stringify([row.nappi_code_value]),
+    }).then((ws) => {
+      if (!cancelled) onUpdate(idx, { _warnings: ws || [] });
+    }).catch(() => {
+      if (!cancelled) onUpdate(idx, { _warnings: [] });
+    });
+    return () => { cancelled = true; };
+  }, [row.nappi_code_value, patient]);
+
+  const hasUncovered = row._warnings.length > 0 && !row._override_reason;
+  const hasCovered   = row._warnings.length > 0 && !!row._override_reason;
+
+  const inputStyle = { fontSize: 12, padding: '4px 8px', borderRadius: 4,
+    border: '1px solid var(--border)', background: 'var(--input-bg, #fff)',
+    color: 'var(--text-dark)', width: '100%', boxSizing: 'border-box' };
+  const labelStyle = { fontSize: 11, color: 'var(--text-muted)', display: 'block',
+    marginBottom: 2 };
+
+  return (
+    <div
+      data-testid={`rx-row-${idx}`}
+      style={{
+        border: `1px solid ${hasUncovered ? 'var(--warning, #f59e0b)' : 'var(--border)'}`,
+        borderRadius: 8, padding: 12, marginBottom: 10,
+        background: hasUncovered ? 'var(--warning-soft, #fffbeb)' : 'var(--surface)',
+        position: 'relative',
+      }}
+    >
+      {!disabled && (
+        <button
+          type="button"
+          data-testid={`rx-row-remove-${idx}`}
+          onClick={() => onRemove(idx)}
+          aria-label={`Remove drug ${idx + 1}`}
+          style={{ position: 'absolute', top: 8, right: 8, background: 'none', border: 'none',
+            cursor: 'pointer', fontSize: 14, color: 'var(--text-muted)', lineHeight: 1 }}
+          title="Remove drug"
+        >✕</button>
+      )}
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 8 }}>
+        <div>
+          <label style={labelStyle}>NAPPI Medicine *</label>
+          <window.MNappiPicker
+            value={row.nappi_code_value}
+            testid={`rx-nappi-${idx}`}
+            onChange={({ code, display }) =>
+              onUpdate(idx, { nappi_code_value: `${code}-NAPPI`, drug_name: display })
+            }
+          />
+        </div>
+        <div>
+          <label style={labelStyle}>Drug Name</label>
+          <input
+            type="text"
+            data-testid={`rx-drugname-${idx}`}
+            value={row.drug_name}
+            onChange={(e) => onUpdate(idx, { drug_name: e.target.value })}
+            style={inputStyle}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8, marginBottom: 8 }}>
+        <div>
+          <label style={labelStyle}>Schedule</label>
+          <input
+            type="text"
+            data-testid={`rx-sched-${idx}`}
+            value={row.schedule}
+            readOnly
+            style={{ ...inputStyle, background: 'var(--bg-subtle)', color: 'var(--text-muted)' }}
+          />
+        </div>
+        <div>
+          <label style={labelStyle}>Strength</label>
+          <input
+            type="text"
+            value={row.strength}
+            onChange={(e) => onUpdate(idx, { strength: e.target.value })}
+            style={inputStyle}
+            disabled={disabled}
+          />
+        </div>
+        <div>
+          <label style={labelStyle}>Dosage Form</label>
+          <input
+            type="text"
+            value={row.dosage_form}
+            onChange={(e) => onUpdate(idx, { dosage_form: e.target.value })}
+            style={inputStyle}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', gap: 8, marginBottom: 8 }}>
+        <div>
+          <label style={labelStyle}>Dosage</label>
+          <input
+            type="text"
+            data-testid={`rx-dosage-${idx}`}
+            value={row.dosage}
+            onChange={(e) => onUpdate(idx, { dosage: e.target.value })}
+            placeholder="e.g. 1 tablet BD"
+            style={inputStyle}
+            disabled={disabled}
+          />
+        </div>
+        <div>
+          <label style={labelStyle}>Duration</label>
+          <input
+            type="text"
+            value={row.period}
+            onChange={(e) => onUpdate(idx, { period: e.target.value })}
+            placeholder="e.g. 7 days"
+            style={inputStyle}
+            disabled={disabled}
+          />
+        </div>
+        <div>
+          <label style={labelStyle}>Repeats Authorised</label>
+          <input
+            type="number"
+            min="0"
+            data-testid={`rx-repeats-${idx}`}
+            value={row.custom_repeats_authorised}
+            onChange={(e) => onUpdate(idx, { custom_repeats_authorised: Number(e.target.value) })}
+            style={inputStyle}
+            disabled={disabled}
+          />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, paddingTop: 16 }}>
+          <input
+            type="checkbox"
+            id={`rx-gensub-${idx}`}
+            checked={!!row.custom_generic_substitution_allowed}
+            onChange={(e) => onUpdate(idx, { custom_generic_substitution_allowed: e.target.checked ? 1 : 0 })}
+            disabled={disabled}
+          />
+          <label htmlFor={`rx-gensub-${idx}`} style={{ fontSize: 11, cursor: 'pointer' }}>
+            Generic sub
+          </label>
+        </div>
+      </div>
+
+      {row._warnings.length > 0 && (
+        <div style={{ marginTop: 6 }}>
+          {row._warnings.map((w, wi) => (
+            <span
+              key={wi}
+              data-testid={`rx-warning-badge-${idx}-${wi}`}
+              title={w.message}
+              style={{
+                display: 'inline-block', fontSize: 10, padding: '2px 8px',
+                borderRadius: 12, marginRight: 6, marginBottom: 4, cursor: 'pointer',
+                background: hasCovered ? 'var(--text-muted)' : 'var(--warning, #f59e0b)',
+                color: '#fff', fontWeight: 600,
+              }}
+              onClick={() => onUpdate(idx, { _override_open: !row._override_open })}
+            >
+              {hasCovered ? '✓ Override noted' : `⚠ ${w.type === 'drug_allergy' ? 'Allergy' : w.type === 'schedule_rule' ? 'Schedule' : 'Interaction'}`}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {row._warnings.length > 0 && (row._override_open || hasUncovered) && (
+        <div
+          data-testid={`rx-override-${idx}`}
+          style={{
+            marginTop: 8, padding: 8, background: 'var(--warning-soft, #fffbeb)',
+            border: '1px solid var(--warning, #f59e0b)', borderRadius: 6,
+          }}
+        >
+          <label style={{ ...labelStyle, fontWeight: 600, color: '#92400e' }}>
+            Override reason (required to proceed) *
+          </label>
+          <textarea
+            data-testid={`rx-override-reason-${idx}`}
+            rows={2}
+            value={row._override_reason}
+            onChange={(e) => onUpdate(idx, { _override_reason: e.target.value })}
+            placeholder="Clinical justification for overriding the warning…"
+            style={{ ...inputStyle, resize: 'vertical', minHeight: 48 }}
+            disabled={disabled}
+          />
+          {row._warnings.map((w, wi) => (
+            <p key={wi} style={{ fontSize: 10, color: '#92400e', margin: '4px 0 0' }}>
+              {w.message}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MPrescriptionPanel({ patient, prescriber, rows, onChange, disabled = false }) {
+  const addRow = () => onChange([...rows, EMPTY_RX_ROW()]);
+
+  const updateRow = (idx, patch) => {
+    const updated = rows.map((r, i) => i === idx ? { ...r, ...patch } : r);
+    onChange(updated);
+  };
+
+  const removeRow = (idx) => onChange(rows.filter((_, i) => i !== idx));
+
+  const hasUncoveredWarnings = rows.some(
+    (r) => r._warnings && r._warnings.length > 0 && !r._override_reason
+  );
+
+  return (
+    <div data-testid="prescription-panel">
+      {rows.length === 0 && (
+        <div
+          data-testid="rx-empty"
+          style={{ textAlign: 'center', color: 'var(--text-muted)', fontSize: 12,
+            padding: '16px 0', borderRadius: 8, border: '1px dashed var(--border)' }}
+        >
+          No medications added yet.
+        </div>
+      )}
+
+      {rows.map((row, idx) => (
+        <MPrescriptionRow
+          key={idx}
+          row={row}
+          idx={idx}
+          patient={patient}
+          prescriber={prescriber}
+          onUpdate={updateRow}
+          onRemove={removeRow}
+          disabled={disabled}
+        />
+      ))}
+
+      {!disabled && (
+        <button
+          type="button"
+          data-testid="rx-add-drug"
+          onClick={addRow}
+          className="btn btn-outline btn-sm"
+          style={{ marginTop: 4 }}
+        >
+          + Add drug
+        </button>
+      )}
+
+      {hasUncoveredWarnings && (
+        <div
+          data-testid="rx-uncovered-warning-notice"
+          role="alert"
+          aria-live="polite"
+          style={{
+            marginTop: 10, padding: '8px 12px', background: 'var(--warning-soft, #fffbeb)',
+            border: '1px solid var(--warning, #f59e0b)', borderRadius: 6,
+            fontSize: 12, color: '#92400e', fontWeight: 500,
+          }}
+        >
+          ⚠ One or more safety warnings require an override reason before saving.
+        </div>
+      )}
+    </div>
+  );
+}
+
+window.MPrescriptionPanel = MPrescriptionPanel;

--- a/medic_plus/public/daystar-health/meridian-select.jsx
+++ b/medic_plus/public/daystar-health/meridian-select.jsx
@@ -1,0 +1,247 @@
+// MSelect — branded dropdown listbox for the daystar-health portal.
+//
+//   <window.MSelect
+//     value="..."                       // current value (string)
+//     onChange={(v) => ...}             // receives the new value, NOT an event
+//     options={[{ value, label }, ...]}  // option list
+//     placeholder="Select…"             // shown when value is empty
+//     searchable={false}                // adds a filter input in the popover
+//     disabled={false}
+//     aria-label="..."
+//     data-testid="..."                 // forwarded to the trigger button
+//     className="..."                   // appended to the trigger class list
+//     style={{...}}                     // applied to the wrapper
+//   />
+//
+// Popover is portal'd to <body> to avoid stacking-context traps from animated
+// ancestors (see register-patient drawer fix).
+
+const { useState: msUseState, useEffect: msUseEffect, useRef: msUseRef, useMemo: msUseMemo } = React;
+
+function MSelect(props) {
+  const {
+    value, onChange, options = [],
+    placeholder = "Select…",
+    searchable = false,
+    disabled,
+    className, style,
+    ...rest
+  } = props;
+
+  const [open, setOpen] = msUseState(false);
+  const [filter, setFilter] = msUseState("");
+  const [highlight, setHighlight] = msUseState(0);
+  const [popoverRect, setPopoverRect] = msUseState({ top: 0, left: 0, width: 280 });
+
+  const wrapperRef = msUseRef(null);
+  const triggerRef = msUseRef(null);
+  const popoverRef = msUseRef(null);
+  const searchRef = msUseRef(null);
+  const itemRefs = msUseRef([]);
+
+  const visibleOptions = msUseMemo(() => {
+    if (!searchable || !filter.trim()) return options;
+    const f = filter.trim().toLowerCase();
+    return options.filter(o => (o.label || o.value || "").toLowerCase().includes(f));
+  }, [options, filter, searchable]);
+
+  const selected = msUseMemo(() => options.find(o => o.value === value), [options, value]);
+
+  const reposition = () => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const width = Math.max(rect.width, 220);
+    const popH = Math.min(360, 60 + visibleOptions.length * 32);
+    let top = rect.bottom + 6;
+    if (top + popH > window.innerHeight && rect.top - 6 - popH > 0) {
+      top = rect.top - 6 - popH;
+    }
+    let left = rect.left;
+    if (left + width > window.innerWidth - 8) left = window.innerWidth - 8 - width;
+    if (left < 8) left = 8;
+    setPopoverRect({ top: top + window.scrollY, left: left + window.scrollX, width });
+  };
+
+  msUseEffect(() => {
+    if (!open) return;
+    reposition();
+    // Set highlight to selected option (or first visible)
+    const idx = Math.max(0, visibleOptions.findIndex(o => o.value === value));
+    setHighlight(idx === -1 ? 0 : idx);
+    if (searchable) {
+      // Defer focus so the popover is mounted.
+      setTimeout(() => searchRef.current?.focus(), 0);
+    }
+    const onScrollOrResize = () => reposition();
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, [open]);
+
+  msUseEffect(() => {
+    if (!open) return;
+    const onDocDown = (e) => {
+      if (wrapperRef.current?.contains(e.target)) return;
+      if (popoverRef.current?.contains(e.target)) return;
+      setOpen(false);
+    };
+    const onKey = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    document.addEventListener("mousedown", onDocDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Keep highlighted item in view while arrowing.
+  msUseEffect(() => {
+    if (!open) return;
+    const node = itemRefs.current[highlight];
+    if (node && node.scrollIntoView) node.scrollIntoView({ block: "nearest" });
+  }, [highlight, open]);
+
+  // Reset filter and highlight when popover closes.
+  msUseEffect(() => {
+    if (!open) {
+      setFilter("");
+      setHighlight(0);
+    }
+  }, [open]);
+
+  const openIfClosed = () => {
+    if (disabled) return;
+    if (!open) setOpen(true);
+  };
+
+  const commit = (opt) => {
+    onChange && onChange(opt.value);
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const onTriggerKey = (e) => {
+    if (disabled) return;
+    if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
+      e.preventDefault();
+      openIfClosed();
+    }
+  };
+
+  const onListKey = (e) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight(h => Math.min(visibleOptions.length - 1, h + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight(h => Math.max(0, h - 1));
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setHighlight(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setHighlight(visibleOptions.length - 1);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const opt = visibleOptions[highlight];
+      if (opt) commit(opt);
+    }
+  };
+
+  const popover = open ? ReactDOM.createPortal(
+    <div
+      ref={popoverRef}
+      className="msel-popover"
+      role="listbox"
+      style={{ top: popoverRect.top, left: popoverRect.left, width: popoverRect.width }}
+      onKeyDown={onListKey}
+    >
+      {searchable && (
+        <div className="msel-search">
+          <input
+            ref={searchRef}
+            className="input"
+            type="text"
+            aria-label="Filter options"
+            placeholder="Search…"
+            value={filter}
+            onChange={(e) => { setFilter(e.target.value); setHighlight(0); }}
+            onKeyDown={onListKey}
+            data-testid="msel-search"
+          />
+        </div>
+      )}
+      <div className="msel-list" role="presentation">
+        {visibleOptions.length === 0 && (
+          <div className="msel-empty">No matches</div>
+        )}
+        {visibleOptions.map((opt, i) => {
+          const isSelected = opt.value === value;
+          const isHighlight = i === highlight;
+          let cls = "msel-item";
+          if (isSelected) cls += " msel-item-selected";
+          if (isHighlight) cls += " msel-item-highlight";
+          return (
+            <button
+              key={opt.value || `__${i}`}
+              ref={(el) => (itemRefs.current[i] = el)}
+              type="button"
+              role="option"
+              aria-selected={isSelected || undefined}
+              className={cls}
+              onMouseEnter={() => setHighlight(i)}
+              onClick={() => commit(opt)}
+              data-testid={isSelected ? "msel-item-selected" : undefined}
+            >
+              <span className="msel-item-label">{opt.label != null ? opt.label : opt.value}</span>
+              {isSelected && <span className="msel-item-check">✓</span>}
+            </button>
+          );
+        })}
+      </div>
+    </div>,
+    document.body
+  ) : null;
+
+  const displayLabel = selected ? (selected.label != null ? selected.label : selected.value) : "";
+
+  return (
+    <div
+      className={`msel${disabled ? " msel-disabled" : ""}`}
+      ref={wrapperRef}
+      style={style}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`input msel-trigger ${className || ""}`}
+        onClick={() => (open ? setOpen(false) : openIfClosed())}
+        onKeyDown={onTriggerKey}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        {...rest}
+      >
+        <span className={`msel-value${displayLabel ? "" : " msel-placeholder"}`}>
+          {displayLabel || placeholder}
+        </span>
+        <span className="msel-chevron" aria-hidden>
+          <window.MIcons.ChevronDown size={14} />
+        </span>
+      </button>
+      {popover}
+    </div>
+  );
+}
+
+window.MSelect = MSelect;

--- a/medic_plus/public/daystar-health/meridian-time-picker.jsx
+++ b/medic_plus/public/daystar-health/meridian-time-picker.jsx
@@ -1,0 +1,276 @@
+// MTimePicker — branded 24-hour time picker for the daystar-health portal.
+//
+//   <window.MTimePicker
+//     value="HH:MM"                // 24-hour, "" when empty
+//     onChange={(v) => ...}        // receives string, NOT an event
+//     onBlur={() => ...}
+//     step={15}                    // minute granularity in the popover (default 15)
+//     disabled={false}
+//     placeholder="HH:MM"
+//     aria-label="..."
+//     data-testid="..."
+//     className="..."              // appended to the input class list
+//     style={{...}}                // applied to the wrapper
+//   />
+//
+// Popover portal'd to <body> for the same stacking-context reason as MDatePicker.
+
+const { useState: tpUseState, useEffect: tpUseEffect, useRef: tpUseRef, useMemo: tpUseMemo } = React;
+
+const TP_TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+function tpPad(n) { return n < 10 ? `0${n}` : `${n}`; }
+function tpParse(value) {
+  if (!value || !TP_TIME_RE.test(value)) return null;
+  const [h, m] = value.split(":").map(Number);
+  return { h, m };
+}
+
+function MTimePicker(props) {
+  const {
+    value, onChange, onBlur,
+    step = 15,
+    disabled,
+    placeholder = "HH:MM",
+    className, style,
+    ...rest
+  } = props;
+
+  const [text, setText] = tpUseState(value || "");
+  const [open, setOpen] = tpUseState(false);
+  const [popoverRect, setPopoverRect] = tpUseState({ top: 0, left: 0, width: 220 });
+
+  const wrapperRef = tpUseRef(null);
+  const inputRef = tpUseRef(null);
+  const popoverRef = tpUseRef(null);
+  const hourColRef = tpUseRef(null);
+  const minuteColRef = tpUseRef(null);
+
+  tpUseEffect(() => {
+    if (document.activeElement !== inputRef.current) {
+      setText(value || "");
+    }
+  }, [value]);
+
+  const minutes = tpUseMemo(() => {
+    const out = [];
+    for (let m = 0; m < 60; m += step) out.push(m);
+    return out;
+  }, [step]);
+
+  const hours = tpUseMemo(() => {
+    const out = [];
+    for (let h = 0; h < 24; h++) out.push(h);
+    return out;
+  }, []);
+
+  const reposition = () => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const width = Math.max(rect.width, 220);
+    const popH = 280;
+    let top = rect.bottom + 6;
+    if (top + popH > window.innerHeight && rect.top - 6 - popH > 0) {
+      top = rect.top - 6 - popH;
+    }
+    let left = rect.left;
+    if (left + width > window.innerWidth - 8) left = window.innerWidth - 8 - width;
+    if (left < 8) left = 8;
+    setPopoverRect({ top: top + window.scrollY, left: left + window.scrollX, width });
+  };
+
+  tpUseEffect(() => {
+    if (!open) return;
+    reposition();
+    // Scroll selected hour/minute into view.
+    setTimeout(() => {
+      const parts = tpParse(text || value);
+      if (!parts) return;
+      const h = hourColRef.current?.querySelector(`[data-h="${parts.h}"]`);
+      const m = minuteColRef.current?.querySelector(`[data-m="${parts.m}"]`);
+      h && h.scrollIntoView && h.scrollIntoView({ block: "center" });
+      m && m.scrollIntoView && m.scrollIntoView({ block: "center" });
+    }, 0);
+    const onScrollOrResize = () => reposition();
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, [open]);
+
+  tpUseEffect(() => {
+    if (!open) return;
+    const onDocDown = (e) => {
+      if (wrapperRef.current?.contains(e.target)) return;
+      if (popoverRef.current?.contains(e.target)) return;
+      setOpen(false);
+    };
+    const onKey = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        inputRef.current?.focus();
+      }
+    };
+    document.addEventListener("mousedown", onDocDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const commit = (hh, mm) => {
+    const iso = `${tpPad(hh)}:${tpPad(mm)}`;
+    setText(iso);
+    onChange && onChange(iso);
+  };
+
+  const pickHour = (h) => {
+    const parts = tpParse(text || value);
+    const m = parts ? parts.m : 0;
+    commit(h, m);
+  };
+  const pickMinute = (m) => {
+    const parts = tpParse(text || value);
+    const h = parts ? parts.h : new Date().getHours();
+    commit(h, m);
+    setOpen(false);
+    inputRef.current?.focus();
+  };
+
+  const onInputChange = (e) => {
+    const raw = e.target.value;
+    setText(raw);
+    if (raw === "") onChange && onChange("");
+    else if (TP_TIME_RE.test(raw)) onChange && onChange(raw);
+  };
+
+  const onInputBlur = (e) => {
+    const parsed = tpParse(text);
+    if (!parsed && text !== "") setText(value || "");
+    onBlur && onBlur(e);
+  };
+
+  const openIfClosed = () => {
+    if (disabled) return;
+    if (!open) setOpen(true);
+  };
+
+  const current = tpParse(text || value);
+
+  const popover = open ? ReactDOM.createPortal(
+    <div
+      ref={popoverRef}
+      className="mtp-popover"
+      role="dialog"
+      aria-label="Choose time"
+      style={{ top: popoverRect.top, left: popoverRect.left, width: popoverRect.width }}
+    >
+      <div className="mtp-cols">
+        <div className="mtp-col" ref={hourColRef} role="listbox" aria-label="Hour">
+          {hours.map((h) => {
+            const isSel = current && current.h === h;
+            return (
+              <button
+                key={h}
+                type="button"
+                role="option"
+                aria-selected={isSel || undefined}
+                data-h={h}
+                className={`mtp-cell${isSel ? " mtp-cell-selected" : ""}`}
+                onClick={() => pickHour(h)}
+              >
+                {tpPad(h)}
+              </button>
+            );
+          })}
+        </div>
+        <div className="mtp-col" ref={minuteColRef} role="listbox" aria-label="Minute">
+          {minutes.map((m) => {
+            const isSel = current && current.m === m;
+            return (
+              <button
+                key={m}
+                type="button"
+                role="option"
+                aria-selected={isSel || undefined}
+                data-m={m}
+                className={`mtp-cell${isSel ? " mtp-cell-selected" : ""}`}
+                onClick={() => pickMinute(m)}
+              >
+                {tpPad(m)}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="mtp-footer">
+        <button
+          type="button"
+          className="mdp-foot-btn"
+          onClick={() => {
+            const now = new Date();
+            const h = now.getHours();
+            const m = Math.round(now.getMinutes() / step) * step;
+            commit(h, m % 60 === 60 ? 0 : m);
+            setOpen(false);
+            inputRef.current?.focus();
+          }}
+        >
+          Now
+        </button>
+        <button
+          type="button"
+          className="mdp-foot-btn"
+          onClick={() => {
+            setText("");
+            onChange && onChange("");
+            setOpen(false);
+            inputRef.current?.focus();
+          }}
+        >
+          Clear
+        </button>
+      </div>
+    </div>,
+    document.body
+  ) : null;
+
+  return (
+    <div className={`mtp${disabled ? " mtp-disabled" : ""}`} ref={wrapperRef} style={style}>
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="numeric"
+        pattern="\d{2}:\d{2}"
+        autoComplete="off"
+        spellCheck={false}
+        className={`input mtp-input ${className || ""}`}
+        placeholder={placeholder}
+        value={text}
+        onChange={onInputChange}
+        onBlur={onInputBlur}
+        onKeyDown={(e) => { if (e.key === "ArrowDown" && !open) { e.preventDefault(); openIfClosed(); } }}
+        disabled={disabled}
+        {...rest}
+      />
+      <button
+        type="button"
+        className="mtp-icon-btn"
+        aria-label="Open clock"
+        tabIndex={-1}
+        onClick={() => (open ? setOpen(false) : openIfClosed())}
+        disabled={disabled}
+      >
+        <window.MIcons.Clock size={15} />
+      </button>
+      {popover}
+    </div>
+  );
+}
+
+window.MTimePicker = MTimePicker;

--- a/medic_plus/www/daystar-health.html
+++ b/medic_plus/www/daystar-health.html
@@ -36,6 +36,9 @@ window.__DAYSTAR_HEALTH__ = {
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-data.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-icons.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-layout.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-date-picker.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-time-picker.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-select.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-auth.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-dashboard.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-patients.jsx"></script>
@@ -45,6 +48,7 @@ window.__DAYSTAR_HEALTH__ = {
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-code-picker.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-icd10-picker.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-new-visit.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-prescription.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-profile.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/tweaks-panel.jsx"></script>
 


### PR DESCRIPTION
## Summary
- Replace native `<select>`/`<input type="date">`/`<input type="time">` in the new-visit drawer with portal-rendered `MSelect`/`MDatePicker`/`MTimePicker` (no more browser-default UI inside a Daystar-branded surface).
- Split `MPrescriptionRow`/`MPrescriptionPanel` out of `meridian-new-visit.jsx` (was 847 lines) into its own `meridian-prescription.jsx`.
- A11y + correctness fixes around the swap-in:
  - Hoist `Field`/tab controls out of `MNewVisitDrawer` (defining them inside meant every keystroke remounted inputs and dropped popover state).
  - `role=tablist`/`tab`/`tabpanel` with `aria-selected`/`aria-controls` and Arrow/Home/End keyboard navigation on the four sections.
  - `role="alert"` on the validation banner + per-field `aria-invalid` and `aria-describedby` on the four required fields.
  - Cancellation flags on the open-effect (Patient/Practitioner/Type list loaders) and the ICD-10 search so late responses can't update closed-drawer state.

## Test plan
- [ ] Open new-visit drawer on `selfserve-staging.thedaystar.co.za/daystar-health` — all four sections render, tabs cycle with ←/→/Home/End.
- [ ] Click *Create encounter* with the form empty — red banner appears (screen reader announces it), Patient / Practitioner / Chief Complaint show as invalid; filling each clears its invalid state.
- [ ] Open the patient select, type to filter, pick a patient — selection sticks, drawer state preserved.
- [ ] Open another input afterwards (e.g. typing in Chief Complaint) — focus stays put, no remount flicker, MSelect popovers don't slam shut on every keystroke.
- [ ] Date picker: type `2026-05-09` manually, then click the calendar icon and pick a different day — both code paths update the form.
- [ ] Time picker: open the popover, scroll/click hours and minutes, hit *Now* — time updates.
- [ ] Open the drawer, immediately close it — no React "setState after unmount" warnings from the in-flight Patient/Practitioner/Appointment-Type fetches.
- [ ] ICD-10 search inside *SOAP*: type a few characters, then close the drawer before results land — no console error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)