### PR TITLE
fix: practitioner schedule hook crashed on save

### DIFF
--- a/medic_plus/api/doc_events.py
+++ b/medic_plus/api/doc_events.py
@@ -112,9 +112,18 @@ def update_checklist_on_member_status(doc, method=None):
 
 
 def update_checklist_on_schedule_created(doc, method=None):
-	"""Step 5 — tick when a Practitioner Schedule is created for this practice."""
+	"""Step 5 — tick when a Healthcare Practitioner has at least one schedule attached.
+
+	Practitioner Schedule itself is a global template doctype with no link back
+	to a practitioner; the relationship lives in
+	Healthcare Practitioner.practitioner_schedules (child table of type
+	Practitioner Service Unit Schedule). So this handler runs on
+	Healthcare Practitioner.on_update and reads that child table.
+	"""
+	if not doc.get("practitioner_schedules"):
+		return
 	practice = frappe.db.get_value(
-		"Practice Member", {"practitioner": doc.practitioner, "role": "Doctor"}, "practice"
+		"Practice Member", {"practitioner": doc.name, "role": "Doctor"}, "practice"
 	)
 	if practice:
 		on_schedule_created(practice)

--- a/medic_plus/hooks.py
+++ b/medic_plus/hooks.py
@@ -227,6 +227,7 @@ doc_events = {
 		"on_update": [
 			"medic_plus.api.doc_events.provision_dispensary_on_update",
 			"medic_plus.api.doc_events.update_checklist_on_signature",
+			"medic_plus.api.doc_events.update_checklist_on_schedule_created",
 		],
 	},
 	# Practice Setup Checklist — steps 1–6
@@ -243,9 +244,6 @@ doc_events = {
 	"Practice Member": {
 		"after_insert": "medic_plus.api.doc_events.update_checklist_on_member_status",
 		"on_update": "medic_plus.api.doc_events.update_checklist_on_member_status",
-	},
-	"Practitioner Schedule": {
-		"after_insert": "medic_plus.api.doc_events.update_checklist_on_schedule_created",
 	},
 	"Sales Invoice": {
 		"after_insert": "medic_plus.api.doc_events.update_checklist_on_first_invoice",


### PR DESCRIPTION
## Summary

`update_checklist_on_schedule_created` was hooked on `Practitioner Schedule.after_insert` and read `doc.practitioner`. That field doesn't exist on Practitioner Schedule (it's a global schedule template — the relationship lives on `Healthcare Practitioner.practitioner_schedules`). Every save crashed with `AttributeError`, blocking schedule creation on `ehealth.thedaystar.co.za`.

## What changed
- Removed the `Practitioner Schedule.after_insert` hook from `hooks.py`.
- Added `update_checklist_on_schedule_created` to the existing `Healthcare Practitioner.on_update` chain.
- Handler now gates on `practitioner_schedules` being populated and resolves the practice via `Practice Member.practitioner = doc.name`.

## Test plan
- [x] `bench --site medic-demo-staging.thedaystar.co.za execute frappe.client.insert` for a fresh Practitioner Schedule → succeeds (would have crashed before).
- [x] Cleanup record deleted; no side-effects on staging data.
- [ ] Verify on prod after deploy: create Practitioner Schedule via Desk on ehealth.thedaystar.co.za.

🤖 Generated with [Claude Code](https://claude.com/claude-code)