### PR TITLE
docs: v2.2.0 release notes + techspec entries

### DIFF
--- a/docs/releases/v2.2.0.md
+++ b/docs/releases/v2.2.0.md
@@ -1,0 +1,71 @@
+# medic_plus v2.2.0
+
+**Release date:** 2026-05-09
+**Theme:** Comprehensive Desk workspace UX + latent class-name orphan fix
+
+This release does two things: it overhauls both Desk workspaces from sparse stubs into polished, comprehensive navigation surfaces, and it closes a latent bug where every `bench migrate` was silently deleting three DocType records from the database before fixture sync re-created them.
+
+## What's new
+
+### Desk workspaces: complete link tree, more shortcuts, real Modules section
+
+Both `Medic Plus Practice` and `Medic Plus Platform` were shipping with the bare minimum: Practice exposed 6 doctype links across 3 cards, and Platform had no link tree at all. Users had to fall back to the global search to reach most of the app's surface.
+
+After this release, both workspaces are comprehensive enough that a user lands on the workspace and can reach any doctype the app touches without typing into search.
+
+#### Medic Plus Practice (Practice Admin / Doctor / Receptionist)
+
+- **6 cards** wrapping **32 doctype links**:
+  - **Patients & Appointments**: Patient, Patient Appointment, Practitioner Schedule, Healthcare Practitioner
+  - **Clinical Records**: Patient Encounter, Sick Note, Vital Signs, Lab Test, Patient Allergy, Patient Chronic Condition, Patient Problem List
+  - **Prescriptions & Dispensary**: Drug Master, Item, Stock Entry, Warehouse, Stock Reconciliation
+  - **Billing & Claims**: Sales Invoice, Payment Entry, Customer, Insurance Claim, Tariff Code, Medical Aid Scheme
+  - **POPIA & Audit**: Clinical Access Log, Data Unmask Request, Patient Consent Record, Telemedicine Consent
+  - **Setup**: Practice, Practice Member, Practice Setup Checklist, Encounter Template, Email Account, Notification
+- **8 shortcuts** (added New Patient Encounter, Today's Schedule, Setup Checklist, Inpatient Dashboard)
+- **6 number cards** (unchanged): Today's Appointments, This Month's Appointments, Total Patients, My Practice Members, Sick Notes Issued, Outstanding AR
+- **1 chart**: Appointments Over Time
+- New **Modules** section in the workspace content layout so the cards actually render
+
+#### Medic Plus Platform (Healthcare Administrator / Administrator)
+
+- **6 cards** wrapping **34 doctype links**:
+  - **Tenancy**: Practice, Practice Member, Practice Registration Request, Practice Setup Checklist
+  - **Patients & Clinical**: Patient, Patient Appointment, Patient Encounter, Inpatient Record, Healthcare Practitioner, Practitioner Schedule, Sick Note
+  - **Audit & Compliance**: Clinical Access Log, Data Unmask Request, Patient Consent Record, Telemedicine Consent, Sub-Processor Register
+  - **Operations**: AI Inference Log, Backup Drill Log, Record Archive Queue, FHIR Access Token, Switch Configuration
+  - **Catalogs & Configuration**: Drug Master, Encounter Template, Tariff Code, Medical Aid Scheme, Medic Plus Settings, Medic Plus Yoco Settings, Practice AI Settings
+  - **Billing**: Subscription Plan, Subscription, Sales Invoice, Payment Entry, Customer, Insurance Claim
+- **9 shortcuts** (added Registration Requests)
+- **9 number cards**, **5 charts**, **3 quick lists** — all unchanged
+- New **Modules** section after Quick Access in the content layout
+
+### Latent class-name orphan fix
+
+Three DocType controllers were defined with class names that didn't match what Frappe's `import_controller` derives from the doctype name. Frappe expects:
+
+- `AI Inference Log` → `AIInferenceLog`
+- `FHIR Access Token` → `FHIRAccessToken`
+- `Practice AI Settings` → `PracticeAISettings`
+
+The classes were named `AiInferenceLog` / `FhirAccessToken` / `PracticeAiSettings` (PascalCase from the snake_case file names). Every `bench migrate` raised `ImportError` for these three, the orphan-doctype cleanup deleted them from the DB, and fixture sync re-created them on the *next* migrate. The bug was self-healing across migrate runs but was definitely costing data integrity guarantees and migrate determinism.
+
+Fixed by renaming the classes to the casing Frappe expects. Verified by running migrate twice in a row with no orphan-doctype removals reported.
+
+## Upgrade notes
+
+- **No data migration required.** This release does not introduce any new doctypes, schema changes, or fixture additions other than the workspace fixture rewrite. The class-rename is internal only — DB rows for AI Inference Log, FHIR Access Token, and Practice AI Settings are unchanged.
+- **Workspace cache.** After the deploy, the existing Workspace records are overwritten by the fixture during `bench migrate`. If a user has the workspace open in their browser when the deploy lands, they may see stale links until they refresh. A hard refresh resolves it.
+- **Personal customizations.** Users who customized the `Medic Plus Practice` or `Medic Plus Platform` workspace via "Customize" will have their customizations preserved (Frappe stores user customizations as a separate `Workspace` doctype row scoped to that user). Only the standard workspaces are replaced.
+
+## What changed under the hood
+
+- `medic_plus/fixtures/workspace.json` — full rewrite (1466 insertions / 187 deletions)
+- `medic_plus/medic_plus/doctype/ai_inference_log/ai_inference_log.py` — class renamed `AiInferenceLog` → `AIInferenceLog`
+- `medic_plus/medic_plus/doctype/fhir_access_token/fhir_access_token.py` — class renamed `FhirAccessToken` → `FHIRAccessToken`
+- `medic_plus/medic_plus/doctype/practice_ai_settings/practice_ai_settings.py` — class renamed `PracticeAiSettings` → `PracticeAISettings`
+
+## Commits
+
+- `188c92e` — fix: align controller class names with Frappe's expected casing
+- `80035d8` — feat: comprehensive Desk workspace link tree, shortcuts, and content layout

--- a/techspec.md
+++ b/techspec.md
@@ -1314,6 +1314,64 @@ Side-effect from cherry-pick `55bdf3b`: `create_practitioner` and `create_practi
 
 ---
 
+## 2026-05-09 — ehealth alias + FHIR base-URL fix
+
+Added `ehealth.thedaystar.co.za` as an nginx alias for the production Frappe site `medic-demo.thedaystar.co.za`, and `ehealth-staging.thedaystar.co.za` for `medic-demo-staging.thedaystar.co.za`. Both hostnames serve the same Frappe site; users can transition off the legacy `medic-demo` hostnames at their own pace.
+
+Implementation:
+- Staging: `bench setup add-domain` adds the alias to `site_config.json["domains"]`; LE cert (`booking-staging.thedaystar.co.za`) expanded to cover the new SAN.
+- Production: per-site SSL conf at `/etc/nginx/conf.d/frappe-sites-ssl.conf` updated to add `ehealth.thedaystar.co.za` to the `medic-demo` `server_name`; cert `medic-demo.thedaystar.co.za` expanded to cover both names.
+- Deploy workflow `.github/workflows/deploy-production.yml` health-check now hits both hostnames so an alias regression fails CI.
+
+Incidental fix: `medic_plus.api.fhir.capability_statement._FHIR_BASE_URL` and `medic_plus.api.fhir.mappers._FHIR_BASE_URL` were hard-coded to `https://medic-demo-staging.thedaystar.co.za/api/fhir/R4`. On production this meant FHIR `id` system URIs and CapabilityStatement `implementation.url` pointed at staging — wrong for any real client. Replaced both with `frappe.utils.get_url()` so the URL is derived per-request from the active host. Now correct on prod, staging, and aliases.
+
+---
+
+## 2026-05-09 — selfserve alias cutover + prod NOPASSWD grant (ops note)
+
+`selfserve.thedaystar.co.za` was previously DNS'd to staging (169.255.58.233) and aliased to `medic-demo-staging`, so real customers signing up at the public URL were landing in the staging DB. The "stuck PRR" that motivated the v2.1.0 admin overrides above turned out to be a customer who had registered via this misrouted URL.
+
+**DNS** (user, at registrar): `selfserve.thedaystar.co.za` → `194.163.129.168` (prod). New `selfserve-staging.thedaystar.co.za` → `169.255.58.233` (staging).
+
+**Prod**: added `selfserve.thedaystar.co.za` and `ehealth.thedaystar.co.za` to `medic-demo.thedaystar.co.za/site_config.json[domains]` (the merged ehealth entry above noted ehealth was set up but the bench-generated `nginx.conf` had drifted — re-running `bench setup nginx --yes` from the new domains array re-asserted both). The live `/etc/nginx/conf.d/frappe-bench.conf` on prod is a **symlink** to `/home/fruppa/frappe-bench/config/nginx.conf`, so the regen updated it in place. Cert `/etc/letsencrypt/live/medic-demo.thedaystar.co.za/cert.pem` expanded via `certbot --nginx --expand` to cover all three SANs (medic-demo + selfserve + ehealth).
+
+**Staging**: site dir renamed `/sites/selfserve.thedaystar.co.za/` → `/sites/selfserve-staging.thedaystar.co.za/`. `domains` arrays in both that dir and `medic-demo-staging/site_config.json` swapped `selfserve` → `selfserve-staging`. The live `/etc/nginx/conf.d/frappe-bench.conf` on staging is **not** a symlink — it's a hand-customized copy with daystar-health SPA rewrites and the marketplace wildcard. Edited in place via `sudo sed -i 's/selfserve\.thedaystar\.co\.za/selfserve-staging.thedaystar.co.za/g'`. Staging shared cert (`/etc/letsencrypt/live/booking-staging.thedaystar.co.za/`) expanded to add `selfserve-staging` and drop `selfserve`.
+
+**Asymmetry to remember**: prod's live nginx config is symlinked from bench's generated one, so `bench setup nginx --yes` updates the live config. Staging's live nginx config is a hand-customized copy that has to be kept in sync manually. Don't assume one workflow on the other server.
+
+**Persistent fix to the sudo wall**: created `/etc/sudoers.d/fruppa-deploy` on prod granting `fruppa` NOPASSWD for `/usr/sbin/nginx`, `/usr/bin/nginx`, `/bin/systemctl reload nginx`, `/bin/systemctl restart nginx`, `/usr/sbin/certbot`, `/usr/bin/certbot`. Anything outside this list still needs the password. This means nginx-tweak-then-reload-then-renew-cert flows can run end-to-end via SSH from the staging box without a human typing a password.
+
+**Stale data**: the customer PRR that motivated v2.1.0 is still in the staging DB (not migrated). They'll need to re-register at `https://selfserve.thedaystar.co.za/signup` (now hitting prod) to land in the correct tenant.
+
+---
+
+## 2026-05-09 — v2.2.0: Desk workspace overhaul + latent class-name orphan fix
+
+Two changes shipped on the same tag.
+
+**Workspace overhaul.** Both `Medic Plus Practice` (sequence 0, for Practice Admin/Doctor/Receptionist) and `Medic Plus Platform` (sequence 1, for Healthcare Administrator/Administrator) had sparse navigation: Practice exposed 6 doctype links across 3 cards (Patients & Appointments / Clinical / Dispensary); Platform had 0 links and relied entirely on shortcuts and charts. Users had to fall back to the global search to reach most of the app's surface — a violation of the "no clicking around" UX rule in `CLAUDE.md`.
+
+Both workspaces are now regenerated by a Python helper (kept in `/tmp/build_workspace.py` during dev, not checked in — fixture is the source of truth) so the structure stays consistent:
+
+- **Medic Plus Practice**: 6 cards (Patients & Appointments · Clinical Records · Prescriptions & Dispensary · Billing & Claims · POPIA & Audit · Setup) wrapping 32 doctype links across every clinical and administrative surface; 8 shortcuts (added New Patient Encounter, Today's Schedule, Setup Checklist, Inpatient Dashboard); 6 number cards (unchanged); 1 chart; new Modules section in `content` so the cards actually render.
+- **Medic Plus Platform**: 6 cards (Tenancy · Patients & Clinical · Audit & Compliance · Operations · Catalogs & Configuration · Billing) wrapping 34 doctype links spanning tenancy, POPIA audit, operational logs, catalogs, and platform billing; 9 shortcuts (added Registration Requests); 9 number cards (unchanged); 5 charts; new Modules section in `content`.
+
+**Class-name orphan fix.** While exercising the migrate cycle to load the new fixture I caught a latent bug. Frappe's `frappe.model.base_document.import_controller` derives the controller class name from the doctype name via `doctype.replace(" ", "").replace("-", "")` — preserving uppercase letters in initialisms. So:
+
+- `AI Inference Log` → expected class `AIInferenceLog`
+- `FHIR Access Token` → expected class `FHIRAccessToken`
+- `Practice AI Settings` → expected class `PracticeAISettings`
+
+The actual classes were `AiInferenceLog` / `FhirAccessToken` / `PracticeAiSettings` (PascalCase derived from the snake_case file names by `bench new-doctype`'s scaffold). `getattr(module, expected_classname, None)` returned `None`, raising `ImportError`, which `frappe.model.sync.remove_orphan_doctypes()` interprets as "the controller is gone" and deletes the DocType row from the DB. Fixture sync re-creates the row on the next migrate, which is why the bug was self-healing and went unnoticed for weeks — until I ran two migrates in a session and watched the second one delete them after the first installed them.
+
+Renamed the three classes in `medic_plus/medic_plus/doctype/{ai_inference_log,fhir_access_token,practice_ai_settings}/{...}.py`. Verified by running migrate twice in a row: first run shows "Orphaned DocType(s) found:" empty, second run same. The two test classes in `medic_plus/tests/ui/test_telemedicine_ai.py` (`TestPracticeAiSettingsUi`, `TestAiInferenceLogUi`) keep their PascalCase names since they're independent test fixtures, not references to the controllers.
+
+**Workspace UX standard saved to memory** (`feedback_workspace_ux_standard.md`): every app's Desk workspace must ship with a complete navigation surface — comprehensive shortcuts, card-grouped doctype links, number cards, charts where they add signal. Sparse workspaces are a P0 polish bug, not a v2 polish task. This is now a non-negotiable for any new app or workspace audit, on par with the responsive-design rule.
+
+**Files**: `medic_plus/fixtures/workspace.json` (regenerated), `medic_plus/medic_plus/doctype/ai_inference_log/ai_inference_log.py`, `medic_plus/medic_plus/doctype/fhir_access_token/fhir_access_token.py`, `medic_plus/medic_plus/doctype/practice_ai_settings/practice_ai_settings.py`.
+
+---
+
 ## Roadmap
 
 - [ ] Prescription print format — Jinja, per-practice letterhead ✅ Done (Phase 1D)


### PR DESCRIPTION
## Summary
- New: \`docs/releases/v2.2.0.md\` — release notes for the workspace overhaul + latent class-name orphan fix
- Updated: \`techspec.md\` — backfills the ehealth alias entry, adds the selfserve alias cutover ops note (real prod surgery from earlier today), and adds the v2.2.0 release entry

Per \`CLAUDE.md\` release discipline. Once merged → main, I'll tag v2.2.0 to trigger CI/CD prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)