### PR TITLE
feat: branded MTextArea + swap new-visit drawer textareas

### DIFF
--- a/medic_plus/public/daystar-health/meridian-new-visit.jsx
+++ b/medic_plus/public/daystar-health/meridian-new-visit.jsx
@@ -391,50 +391,38 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
           aria-labelledby="new-visit-tab-soap"
           style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
         >
-          <NVField label="History of Presenting Illness">
-            <textarea
-              data-testid="new-visit-hopi"
-              rows={3}
-              value={form.hopi}
-              onChange={(e) => update('hopi', e.target.value)}
-              className="input"
-              style={{ resize: 'vertical', minHeight: 60 }}
-              placeholder="Background and history…"
-            />
-          </NVField>
-          <NVField label="Subjective (S)">
-            <textarea
-              data-testid="new-visit-subjective"
-              rows={3}
-              value={form.subjective}
-              onChange={(e) => update('subjective', e.target.value)}
-              className="input"
-              style={{ resize: 'vertical', minHeight: 60 }}
-              placeholder="Patient's description of symptoms…"
-            />
-          </NVField>
-          <NVField label="Objective (O)">
-            <textarea
-              data-testid="new-visit-objective"
-              rows={3}
-              value={form.objective}
-              onChange={(e) => update('objective', e.target.value)}
-              className="input"
-              style={{ resize: 'vertical', minHeight: 60 }}
-              placeholder="Vital signs, physical findings…"
-            />
-          </NVField>
-          <NVField label="Assessment (A)">
-            <textarea
-              data-testid="new-visit-assessment-text"
-              rows={2}
-              value={form.assessment_text}
-              onChange={(e) => update('assessment_text', e.target.value)}
-              className="input"
-              style={{ resize: 'vertical', minHeight: 48 }}
-              placeholder="Clinical impression / diagnosis…"
-            />
-          </NVField>
+          <window.MTextArea
+            data-testid="new-visit-hopi"
+            label="History of Presenting Illness"
+            rows={3}
+            value={form.hopi}
+            onChange={(v) => update('hopi', v)}
+            placeholder="Background and history…"
+          />
+          <window.MTextArea
+            data-testid="new-visit-subjective"
+            label="Subjective (S)"
+            rows={3}
+            value={form.subjective}
+            onChange={(v) => update('subjective', v)}
+            placeholder="Patient's description of symptoms…"
+          />
+          <window.MTextArea
+            data-testid="new-visit-objective"
+            label="Objective (O)"
+            rows={3}
+            value={form.objective}
+            onChange={(v) => update('objective', v)}
+            placeholder="Vital signs, physical findings…"
+          />
+          <window.MTextArea
+            data-testid="new-visit-assessment-text"
+            label="Assessment (A)"
+            rows={2}
+            value={form.assessment_text}
+            onChange={(v) => update('assessment_text', v)}
+            placeholder="Clinical impression / diagnosis…"
+          />
           <NVField label="ICD-10 Code">
             <div style={{ position: 'relative' }}>
               {form.assessment_code ? (
@@ -487,17 +475,14 @@ function MNewVisitDrawer({ open, onClose, onCreated, prefillPatient }) {
               )}
             </div>
           </NVField>
-          <NVField label="Plan (P)">
-            <textarea
-              data-testid="new-visit-plan"
-              rows={3}
-              value={form.plan}
-              onChange={(e) => update('plan', e.target.value)}
-              className="input"
-              style={{ resize: 'vertical', minHeight: 60 }}
-              placeholder="Treatment plan, follow-up, referrals…"
-            />
-          </NVField>
+          <window.MTextArea
+            data-testid="new-visit-plan"
+            label="Plan (P)"
+            rows={3}
+            value={form.plan}
+            onChange={(v) => update('plan', v)}
+            placeholder="Treatment plan, follow-up, referrals…"
+          />
         </div>
       )}
 

--- a/medic_plus/public/daystar-health/meridian-textarea.jsx
+++ b/medic_plus/public/daystar-health/meridian-textarea.jsx
@@ -1,0 +1,84 @@
+// MTextArea — branded textarea for the daystar-health portal.
+//
+//   <window.MTextArea
+//     value={form.hopi}
+//     onChange={(v) => update('hopi', v)}    // receives string, NOT an event
+//     onBlur={() => ...}
+//     label="Description"
+//     hint="This is a hint text to help the user."
+//     isRequired={false}
+//     placeholder="..."
+//     rows={3}
+//     disabled={false}
+//     autoFocus={false}
+//     aria-label="..."
+//     data-testid="..."
+//     className="..."             // appended to the textarea class list
+//     style={{...}}                // applied to the wrapper
+//   />
+//
+// Visual style matches the branded MDatePicker / MTimePicker: same border,
+// focus ring, label typography. Resizes vertically by default. No
+// auto-resize (use a fixed `rows` count). Hint text gets `aria-describedby`
+// so screen readers announce it after the label.
+
+const { useId: taUseId } = React;
+
+let _taIdCounter = 0;
+function taFallbackId() {
+  _taIdCounter += 1;
+  return `mta-${_taIdCounter}`;
+}
+
+function MTextArea(props) {
+  const {
+    value, onChange, onBlur,
+    label, hint, isRequired,
+    placeholder = "",
+    rows = 3,
+    disabled, autoFocus,
+    id: idProp,
+    className, style,
+    ...rest
+  } = props;
+
+  // useId is React 18+; fall back for safety in case of older react bundles.
+  const generatedId = (taUseId ? taUseId() : null) || React.useMemo(() => taFallbackId(), []);
+  const id = idProp || `mta-${generatedId}`;
+  const hintId = hint ? `${id}-hint` : undefined;
+
+  const userAriaDescribedBy = rest["aria-describedby"];
+  const ariaDescribedBy = [hintId, userAriaDescribedBy].filter(Boolean).join(" ") || undefined;
+
+  const handleChange = (e) => {
+    if (onChange) onChange(e.target.value);
+  };
+
+  return (
+    <div className={`mta${disabled ? " mta-disabled" : ""}`} style={style}>
+      {label && (
+        <label className="mta-label" htmlFor={id}>
+          {label}
+          {isRequired && <span className="mta-required" aria-hidden="true">*</span>}
+        </label>
+      )}
+      <textarea
+        id={id}
+        className={`mta-input ${className || ""}`}
+        rows={rows}
+        placeholder={placeholder}
+        value={value ?? ""}
+        onChange={handleChange}
+        onBlur={onBlur}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        aria-required={isRequired || undefined}
+        {...rest}
+        aria-describedby={ariaDescribedBy}
+      />
+      {hint && <div id={hintId} className="mta-hint">{hint}</div>}
+    </div>
+  );
+}
+
+window.MTextArea = MTextArea;

--- a/medic_plus/public/daystar-health/meridian.css
+++ b/medic_plus/public/daystar-health/meridian.css
@@ -67,4 +67,44 @@
   cursor: pointer;
 }
 .cal-event.urgent { background: var(--danger-soft); border-left-color: var(--danger); color: #b91c1c; }
+
+/* ── MTextArea ─────────────────────────────────────────────────────────── */
+.mta { display: flex; flex-direction: column; gap: 6px; width: 100%; min-width: 0; }
+.mta-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.mta-required {
+  color: var(--danger, #ef4444);
+  margin-left: 2px;
+  font-weight: 600;
+}
+.mta-input {
+  width: 100%;
+  min-height: 60px;
+  padding: 8px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.4;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.mta-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.mta-input::placeholder { color: var(--text-dim); }
+.mta-input[aria-invalid="true"] { border-color: var(--danger, #ef4444); }
+.mta-input:disabled { cursor: not-allowed; opacity: 0.6; }
+.mta-hint { font-size: 11px; color: var(--text-muted); }
+.mta-disabled .mta-label { opacity: 0.6; }
 .cal-event.followup { background: var(--info-soft); border-left-color: var(--info); }

--- a/medic_plus/www/daystar-health.html
+++ b/medic_plus/www/daystar-health.html
@@ -39,6 +39,7 @@ window.__DAYSTAR_HEALTH__ = {
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-date-picker.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-time-picker.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-select.jsx"></script>
+<script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-textarea.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-auth.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-dashboard.jsx"></script>
 <script type="text/babel" src="/assets/medic_plus/daystar-health/meridian-patients.jsx"></script>


### PR DESCRIPTION
## Summary

Add \`window.MTextArea\` matching the API spec'd at session start:

\`\`\`jsx
<window.MTextArea
  label="Description"
  hint="..."
  isRequired={false}
  placeholder="..."
  rows={3}
  value={form.foo}
  onChange={(v) => update('foo', v)}  // string, not event
/>
\`\`\`

Swap all five new-visit drawer textareas (HOPI, Subjective, Objective, Assessment, Plan) to \`MTextArea\`. Drops the \`NVField\` wrappers since label is now part of the component.

## Notes
- Visual style matches \`MDatePicker\` / \`MTimePicker\`: same border, focus ring, label typography.
- CSS under \`.mta-*\` prefix (mirrors \`.mdp-*\`, \`.mtp-*\`).
- Vertical resize, no auto-resize. Fixed \`rows\`.
- \`hint\` wired via \`aria-describedby\`. \`isRequired\` shows asterisk + sets \`aria-required\`.
- \`aria-invalid\` passes through for future validation wiring.

## Test plan
- [x] \`/daystar-health\` returns 200 on staging
- [x] \`/assets/medic_plus/daystar-health/meridian-textarea.jsx\` returns 200
- [x] Both \`meridian-select\` and \`meridian-textarea\` script tags present in rendered HTML
- [ ] After deploy: open new-visit drawer, type in each SOAP textarea, save, confirm values persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)